### PR TITLE
First Python version with simple architecture

### DIFF
--- a/iup/build_projection_model.py
+++ b/iup/build_projection_model.py
@@ -1,0 +1,54 @@
+import polars as pl
+from sklearn.linear_model import LinearRegression
+
+
+def build_projection_model(data):
+    """
+    Fits a linear regression model to explain per-day incident uptake.
+
+    Parameters
+    ----------
+    data : DataFrame
+        Uptake data as imported and formatted by get_uptake_data.py
+
+    Details
+    -------
+
+    THIS DOES NOT YET SUPPORT YEARLY VARIATION OR MULTIPLE STATES.
+    The data is prepared for regression modeling in several ways.
+    The first report is removed (because it has no previous incident uptake),
+    and if the first report's interval is far from the average interval,
+    the second report is also removed (because its previous incident uptake
+    is unreliable). For each report, the model predictors - the time elapsed
+    since rollout and the previous report's per-day incident uptake - are
+    standardized, as is the model outcome - the per-day incident uptake.
+    Finally, a linear regression is fit that explains the outcome based on
+    an intercept, the individual predictors, and their interaction.
+
+    Returns
+    -------
+    LinearRegression
+        Fitted model of incident uptake.
+    """
+    if ((data["interval"] - data["interval"].mean()) / data["interval"].std())[0] > 1:
+        data = data.slice(2, data.height - 1)
+    else:
+        data = data.slice(1, data.height - 1)
+
+    data = data.with_columns(
+        previous_std=(pl.col("previous") - pl.mean("previous")) / pl.std("previous"),
+        elapsed_std=(pl.col("elapsed") - pl.mean("elapsed")) / pl.std("elapsed"),
+        daily_std=(pl.col("daily") - pl.mean("daily")) / pl.std("daily"),
+    )
+
+    x = (
+        data.select(["previous_std", "elapsed_std"])
+        .with_columns(interact=pl.col("previous_std") * pl.col("elapsed_std"))
+        .to_numpy()
+    )
+    y = data.select(["daily_std"]).to_numpy()
+
+    model = LinearRegression()
+    model.fit(x, y)
+
+    return model

--- a/iup/get_uptake_data.py
+++ b/iup/get_uptake_data.py
@@ -1,0 +1,111 @@
+import polars as pl
+import datetime as dt
+
+
+def get_uptake_data(
+    file_name,
+    state_col,
+    date_col,
+    cumulative_col,
+    state_key,
+    date_format,
+    start_date,
+    filters=None,
+):
+    """
+    Imports and formats past cumulative uptake data from a file or url.
+
+    Parameters
+    ----------
+    file_name : str
+        Path or url address to the .csv file of input data
+    state_col : str
+        Name of the .csv column containing the geographic region
+    date_col : str
+        Name(s) of the .csv column(s) containing the report date
+    cumulative_col : str
+        Name of the .csv column giving cumulative uptake
+    state_key : str
+        Path to .csv file with columns "Abbr" and "Full"
+        for geographic region names
+    date_format : str
+        Format of the dates in date_col, e.g. "%m-%d-%Y",
+        ignored if dates are split into multiple columns
+    start_date : str
+        Date of the season's immunization rollout, in date_format
+    filters : Optional[dict]
+        Dictionary of filters to apply to the data, where
+        keys are column names and values are (lists of) acceptable entries
+
+    Details
+    -------
+
+    The data is imported and optionally filtered. Only geographic regions
+    named in the state key are kept, and their names are abbreviated.
+    Each report data is coerced to "%Y-%m-%d" format. If multiple columns
+    are used to give date ranges, the final date in the range is used.
+    Season the calendar year during the autumn portion of the disease season.
+    Number of days elapsed since rollout, time intervals between reports,
+    incident uptake on each report, per-day incident uptake, and the previous
+    report's per-day incident uptake are also recorded as columns.
+
+    Returns
+    -------
+    DataFrame
+        Past cumulative uptake information.
+    """
+    data = (
+        (pl.read_csv(file_name))
+        .with_columns(cumulative=pl.col(cumulative_col).cast(pl.Float64, strict=False))
+        .drop_nulls(subset=["cumulative"])
+    )
+
+    if filters is not None:
+        filter_expr = pl.lit(True)
+        for k, v in filters.items():
+            filter_expr &= pl.col(k).is_in(pl.lit(v))
+        data = data.filter(filter_expr)
+
+    state_key = pl.read_csv(state_key)
+    data = data.with_columns(
+        state=pl.col(state_col).replace(state_key["Full"], state_key["Abbr"])
+    ).filter(pl.col("state").is_in(state_key["Abbr"]))
+
+    if type(date_col) is list:
+        data = data.with_columns(
+            pl.col(date_col).cast(pl.String),
+            date=pl.concat_str(pl.col(date_col), separator=" "),
+        ).with_columns(
+            pl.col("date")
+            .str.split("-")
+            .list.get(1)
+            .str.strip_chars()
+            .str.to_date(format="%B %e %Y")
+        )
+    else:
+        data = data.with_columns(date=pl.col(date_col).str.to_date(format=date_format))
+
+    start_date = dt.datetime.strptime(start_date, date_format)
+    data = data.with_columns(
+        elapsed=(pl.col("date") - start_date).cast(pl.Float64)
+        / (1000000 * 60 * 60 * 24),
+        season=pl.col("date").dt.year()
+        + pl.when(pl.col("date").dt.month() < 7).then(-1).otherwise(0),
+    )
+
+    data = data.select(["state", "date", "elapsed", "season", "cumulative"]).sort(
+        "state", "date"
+    )
+
+    data = (
+        data.with_columns(
+            incident=(pl.col("cumulative") - pl.col("cumulative").shift(1))
+            .fill_null(pl.col("cumulative").first())
+            .over("state"),
+            interval=pl.col("elapsed").diff().fill_null(pl.col("elapsed").first()),
+        )
+        .with_columns(daily=(pl.col("incident") / pl.col("interval")))
+        .with_columns(previous=pl.col("daily").shift(1))
+    )
+
+    return data

--- a/iup/make_projections.py
+++ b/iup/make_projections.py
@@ -1,0 +1,126 @@
+import polars as pl
+import datetime as dt
+import numpy as np
+
+
+def make_projections(
+    data,
+    model,
+    start_date,
+    end_date,
+    interval,
+    init_elapsed,
+    init_interval,
+    init_incident,
+    init_cumulative,
+):
+    """
+    Uses a linear regression model to project per-day incident uptake.
+
+    Parameters
+    ----------
+    data : DataFrame
+        Uptake data used to fit the projection model,
+        as imported and formatted by get_uptake_data.py
+    model: LinearRegression
+        Linear regression model object from scikit-learn
+        that is fit to the uptake data
+    start_date: string
+        Date for which current uptake information is known,
+        in %Y-%m-%d format
+    end_date: string
+        Date for through which uptake projections are desired,
+        in %Y-%m-%d format
+    interval: string
+        Time interval between projection days, as specified in
+        polars.date_range()
+    init_elapsed: number
+        Number of days since rollout on the start_date
+    init_interval: number
+        Number of days since the previous report on the start_date
+    init_incident: number
+        Incident uptake as reported on the start_date
+    init_cumulative: number
+        Cumulative uptake as reported on the start_date
+
+    Details
+    -------
+
+    THIS DOES NOT YET SUPPORT YEARLY VARIATION, MULTIPLE STATES,
+    OR DIFFERENT MODEL STRUCTURES.
+    The data used to fit the projection model are provided and trimmed
+    (by removing the first 1-2 rows) exactly as in build_projection_model.py,
+    to extract the exact standardization constants used in the model.
+    An output DataFrame is built to mirror the structure of the training data,
+    but for the dates on which projection is desired. Projection is performed
+    one date at a time sequentially, which allows error and/or uncertainty
+    to propagate. Uncertainty is not included here, because the ordinary least
+    squares prediction intervals are neither forthcoming from scikit-learn, nor
+    do they generalize to the Bayesian projection model fitting we ultimately
+    desire. Projections for daily average uptake are transformed to incident
+    and cumulative uptake.
+
+    Returns
+    -------
+    DataFrame
+        Projected incident and cumulative uptake.
+    """
+    if ((data["interval"] - data["interval"].mean()) / data["interval"].std())[0] > 1:
+        train_data = data.slice(2, data.height - 1)
+    else:
+        train_data = data.slice(1, data.height - 1)
+
+    previous_mn = train_data["previous"].mean()
+    previous_sd = train_data["previous"].std()
+    elapsed_mn = train_data["elapsed"].mean()
+    elapsed_sd = train_data["elapsed"].std()
+    daily_mn = train_data["daily"].mean()
+    daily_sd = train_data["daily"].std()
+
+    output = (
+        pl.date_range(
+            start=dt.datetime.strptime(start_date, "%Y-%m-%d"),
+            end=dt.datetime.strptime(end_date, "%Y-%m-%d"),
+            interval=interval,
+            eager=True,
+        )
+        .alias("date")
+        .to_frame()
+        .with_columns(
+            state=pl.lit(train_data.select(pl.col("state").unique())),
+            elapsed=(
+                (pl.col("date") - dt.datetime.strptime(start_date, "%Y-%m-%d")).cast(
+                    pl.Float64
+                )
+                / (1000000 * 60 * 60 * 24)
+            )
+            + init_elapsed,
+            season=pl.col("date").dt.year()
+            + pl.when(pl.col("date").dt.month() < 7).then(-1).otherwise(0),
+        )
+        .with_columns(interval=pl.col("elapsed").diff().fill_null(init_interval))
+    )
+
+    proj = np.zeros((output.shape[0]))
+    proj[0] = init_incident / init_interval
+
+    for i in range(proj.shape[0] - 1):
+        x = np.column_stack(
+            (
+                (proj[i] - previous_mn) / previous_sd,
+                (output["elapsed"][i + 1] - elapsed_mn) / elapsed_sd,
+            )
+        )
+        x = np.insert(x, 2, np.array((x[:, 0] * x[:, 1])), axis=1)
+        y = model.predict(x)
+        proj[i + 1] = y[(0, 0)] * daily_sd + daily_mn
+
+    output = (
+        output.with_columns(daily=pl.Series(proj))
+        .with_columns(incident=pl.col("daily") * pl.col("interval"))
+        .with_columns(
+            cumulative=pl.col("incident").cum_sum() + init_cumulative - init_incident
+        )
+    )
+
+    return output

--- a/scripts/projection_script.py
+++ b/scripts/projection_script.py
@@ -1,0 +1,66 @@
+from get_uptake_data import get_uptake_data
+from build_projection_model import build_projection_model
+from make_projections import make_projections
+
+# Load 2022 IIS data for USA
+iis_usa_2022 = get_uptake_data(
+    file_name="https://data.cdc.gov/api/views/unsk-b7fc/rows.csv?accessType=DOWNLOAD",
+    state_col="Location",
+    date_col="Date",
+    cumulative_col="Bivalent_Booster_18Plus_Pop_Pct",
+    state_key="USA_Name_Key.csv",
+    date_format="%m/%d/%Y",
+    start_date="9/2/2022",
+)
+
+# Load 2022 NIS data for USA
+nis_usa_2022 = get_uptake_data(
+    file_name="https://data.cdc.gov/api/views/akkj-j5ru/rows.csv?accessType=DOWNLOAD",
+    state_col="Geography",
+    date_col=["Time Period", "Year"],
+    cumulative_col="Estimate (%)",
+    state_key="USA_Name_Key.csv",
+    date_format="%m/%d/%Y",
+    start_date="9/2/2022",
+    filters={
+        "Indicator Category": "Received updated bivalent booster dose (among adults who completed primary series)"
+    },
+)
+
+# Load 2023 NIS data for USA
+nis_usa_2023 = get_uptake_data(
+    file_name="NIS_2023-24.csv",
+    state_col="geography",
+    date_col="date",
+    cumulative_col="estimate",
+    state_key="USA_Name_Key.csv",
+    date_format="%m/%d/%Y",
+    start_date="9/12/2023",
+    filters={"time_type": "Weekly", "group_name": "Overall"},
+)
+
+# Build and use a forward projection model for the IIS 2022 data
+iis_usa_2022_model = build_projection_model(iis_usa_2022)
+iis_usa_2022_proj = make_projections(
+    iis_usa_2022, iis_usa_2022_model, "2022-10-19", "2023-05-10", "1w", 47, 7, 1.7, 7.3
+)
+
+# Build and use a forward projection model for the NIS 2022 data
+nis_usa_2022_model = build_projection_model(nis_usa_2022)
+nis_usa_2022_proj = make_projections(
+    nis_usa_2022, nis_usa_2022_model, "2022-09-17", "2023-06-30", "1w", 15, 7, 1.6, 2.2
+)
+
+# Build and use a forward projection model for the NIS 2023 data
+nis_usa_2023_model = build_projection_model(nis_usa_2023)
+nis_usa_2023_proj = make_projections(
+    nis_usa_2023,
+    nis_usa_2023_model,
+    "2022-10-07",
+    "2023-05-11",
+    "1w",
+    25,
+    7,
+    1.3101,
+    4.299,
+)


### PR DESCRIPTION
This is the Python version of my original R, consisting of three functions (in /iup) and a script that calls them sequentially (in /scripts). Either IIS or NIS data is imported and formatted, a linear regression model is fit to the per-day incident uptake, and projections from this linear model are generated. Projections are returned as a DataFrame in the same format as the original data.

This code is meant to be minimal. Many features (some of which were present in the R version) are omitted here, e.g.:
- scaling between data sets
- interpolation of dates
- ability to specify any model other than:   uptake ~ 1 + time_elapsed + previous_uptake + time_elapsed*previous_uptake
- group-level variation on state or calendar year
- quantification of projection uncertainty
- any graphical anything

The purpose of this PR is to get a minimal Python version in our shared space. That way, @Fuhan-Yang has a starting point for building evaluation metrics in Python, while I can build in more features and smarter architectures with the help of @swo.