### PR TITLE
Example: operate over data frame groups

### DIFF
--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,3 +1,0 @@
-def test_trivial():
-    """Trivial test so that pytest suite doesn't complain about no tests"""
-    pass

--- a/tests/test_uptake_data.py
+++ b/tests/test_uptake_data.py
@@ -4,22 +4,77 @@ from polars.testing import assert_frame_equal
 import polars as pl
 
 
-def test_inc_uptake_trim_outlier():
+def test_inc_uptake_minimum_4_data_points():
+    """If there are only 3 data points, drop all of them"""
+    assert (
+        IncidentUptakeData(
+            {
+                "region": "TX",
+                "date": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)],
+                "estimate": 0.0,
+                "interval": "BOGUS",
+            }
+        )
+        .trim_outlier_intervals()
+        .shape[0]
+        == 0
+    )
+
+
+def test_inc_uptake_trim_outlier2():
     """If all dates are equally spaced, drop the first two rows"""
+    dates = [
+        date(2020, 1, 1),
+        date(2020, 1, 2),
+        date(2020, 1, 3),
+        # note that dates cannot be exactly evenly spaced, because then
+        # standardization ends up with zero SD in the denominator
+        date(2020, 1, 5),
+    ]
+
     input_df = IncidentUptakeData(
         {
-            "region": ["TX"] * 3 + ["CA"] * 3,
-            "date": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)] * 2,
-            "estimate": [0.1] * 6,
-            "interval": "week",
+            "region": ["TX"] * len(dates) + ["CA"] * len(dates),
+            "date": dates * 2,
+            "estimate": 0.0,
+            "interval": "BOGUS",
         }
-    ).with_columns(
-        interval=IncidentUptakeData.date_to_interval(pl.col("date")),
-        elapsed=IncidentUptakeData.date_to_elapsed(pl.col("date")),
+    )
+
+    grouping_vars = ("region",)
+    df = input_df.trim_outlier_intervals(grouping_vars)
+
+    # we should have dropped two dates per region
+    assert df.shape[0] == (len(dates) - 2) * 2
+
+    # check the actual values
+    expected = input_df.filter(pl.col("date") >= date(2020, 1, 3))
+    assert_frame_equal(df, expected, check_row_order=False)
+
+
+def test_inc_uptake_trim_outlier3():
+    """If the first two dates are widely spaced, drop the first three rows"""
+    dates = [
+        date(2020, 1, 1),
+        # note the big jump from Jan 1 to Feb 1
+        date(2020, 2, 1),
+        date(2020, 2, 2),
+        date(2020, 2, 3),
+    ]
+    input_df = IncidentUptakeData(
+        {
+            "region": ["TX"] * len(dates) + ["CA"] * len(dates),
+            "date": dates * 2,
+            "estimate": 0.0,
+            "interval": "BOGUS",
+        }
     )
 
     df = input_df.trim_outlier_intervals()
 
-    expected = input_df.filter(pl.col("elapsed") >= 2)
+    # we should have lost 3 dates per region
+    assert df.shape[0] == (len(dates) - 3) * 2
 
+    # check the actual values
+    expected = input_df.filter(pl.col("date") >= date(2020, 2, 3))
     assert_frame_equal(df, expected, check_row_order=False)

--- a/tests/test_uptake_data.py
+++ b/tests/test_uptake_data.py
@@ -1,0 +1,25 @@
+from iup import IncidentUptakeData
+from datetime import date
+from polars.testing import assert_frame_equal
+import polars as pl
+
+
+def test_inc_uptake_trim_outlier():
+    """If all dates are equally spaced, drop the first two rows"""
+    input_df = IncidentUptakeData(
+        {
+            "region": ["TX"] * 3 + ["CA"] * 3,
+            "date": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)] * 2,
+            "estimate": [0.1] * 6,
+            "interval": "week",
+        }
+    ).with_columns(
+        interval=IncidentUptakeData.date_to_interval(pl.col("date")),
+        elapsed=IncidentUptakeData.date_to_elapsed(pl.col("date")),
+    )
+
+    df = input_df.trim_outlier_intervals()
+
+    expected = input_df.filter(pl.col("elapsed") >= 2)
+
+    assert_frame_equal(df, expected, check_row_order=False)


### PR DESCRIPTION
- Add a test for `IncidentUptakeData.trim_outlier_intervals()` method
- Rework that method to avoid manually iterating over regions:
  - Fundamental logic is that you always keep row 4 and after, and you keep row 3 only if the standardized interval in row 2 is below some threshold. This can be done with normal dplyr verbs.
  - Use `.over()` to allow for arbitrary groupings.
- Add tests that confirm that:
  - If you have 3 or fewer rows, you throw them all out (because the standardized interval is undefined)
  - You can group over different things
- Speaks to #39, but does not apply a solution across the whole codebase