### PR TITLE
Use `map_groups()` for group-wise operations

### DIFF
--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -504,6 +504,12 @@ class LinearIncidentUptakeModel(UptakeModel):
     - number of days "elapsed" between rollout and the report date
     - daily-average uptake for the interval preceding the "previous" report date
     - interaction of "elapsed" and "previous"
+
+    Let t_i be increasing time points and UR_i be the uptake rate (e.g., uptake
+    per day) between times t_i-1 and t_i (i.e., uptake up to time t_i). Then the
+    model is:
+
+    UR_i = beta0 + beta1*UR_i-1 + beta2*t_i + beta3*UR_i-1*t_i + error
     """
 
     def __init__(self):

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -627,6 +627,73 @@ class LinearIncidentUptakeModel(UptakeModel):
 
         return self
 
+    def _predict1(self, X: pl.DataFrame) -> pl.DataFrame:
+        # check for needed columns
+        assert "elapsed" in X.columns
+        assert set(self.group_vars).issubset(X.columns)
+        assert all(len(X[col].unique()) == 1 for col in self.group_vars)
+
+        # make a {group variable => value} dictionary, so we can pull out the "last"
+        # values in self.start
+        group_values = {col: X[col].unique() for col in self.group_vars}
+        # all group columns must have unique values
+        assert all(len(value) == 1 for value in group_values.values())
+
+        # start with zeros, equal to number of input rows, plus one (to be trimmed)
+        proj = np.zeros(X.shape[0] + 1)
+
+        # first projected value is equal to the last value in
+        # the original data
+        proj[0] = self.start.filter(
+            [pl.col(col) == pl.lit(X[col].unique()) for col in self.group_vars]
+        )["last_daily"][0]
+
+        # iterate over index `i` for each place in the projection
+        for i in range(proj.shape[0] - 1):
+            # x has three rows
+            # row 1 are "daily" values
+            # row 2 are "elapsed" values
+            # row 3 are interaction (daily*elapsed) values
+            # initialize column 1 with:
+            #  - row 1 is the "daily" value in the training data (does this assume
+            #    that the predictions are all after the training period?)
+            #  - row 2 is the time elapsed since the start date until the first date
+            #    to be predicted
+            #  - row 3 is the interaction
+            x = np.column_stack(
+                (
+                    # de-standardize the previous output value
+                    standardize(
+                        proj[i],
+                        self.standards["previous"]["mean"],
+                        self.standards["previous"]["std"],
+                    ),
+                    standardize(
+                        X["elapsed"][i],
+                        self.standards["elapsed"]["mean"],
+                        self.standards["elapsed"]["mean"],
+                    ),
+                )
+            )
+            x = np.insert(x, 2, np.array((x[:, 0] * x[:, 1])), axis=1)
+            # use the fitted linear model to predict the value for the next (i+1)
+            # forecast value, and then de-standardize
+            y = self.model.predict(x)
+            proj[i + 1] = unstandardize(
+                y[(0, 0)],
+                self.standards["daily"]["mean"],
+                self.standards["daily"]["std"],
+            )
+            # in the first iteration, the "daily" value to be fitted is the last
+            # value from the training data. in other iterations, it is the predicted
+            # value from the iteration before.
+
+        # add estimate, which is the estimated uptake rate times the duration of the
+        # uptake period
+        return X.with_columns(daily=np.delete(proj, 0)).with_columns(
+            estimate=pl.col("daily") * pl.col("interval")
+        )
+
     def predict(
         self,
         start_date: dt.date,
@@ -712,75 +779,9 @@ class LinearIncidentUptakeModel(UptakeModel):
             .drop(["last_elapsed", "last_interval"])
         )
 
-        # `regions` is a data frame, one row per region, with columns `region` and `count`
-        regions = self.incident_projection["region"].value_counts()
-
-        # `r` is an integer index over range of number of regions
-        for r in range(regions.shape[0]):
-            # start with zeros, equal to number of rows that had region `r` in the original
-            # data, plus one (to undo trimming?)
-            proj = np.zeros((regions["count"][r]) + 1)
-            # first projected value (the bonus one) is equal to the last value in
-            # the original data
-            proj[0] = self.start.filter(pl.col("region") == regions["region"][r])[
-                "last_daily"
-            ][0]
-
-            # iterate over index `i` for each place in the projection
-            for i in range(proj.shape[0] - 1):
-                # x has three rows
-                # row 1 are "daily" values
-                # row 2 are "elapsed" values
-                # row 3 are interaction (daily*elapsed) values
-                # initialize column 1 with:
-                #  - row 1 is the "daily" value in the training data (does this assume
-                #    that the predictions are all after the training period?)
-                #  - row 2 is the time elapsed since the start date until the first date
-                #    to be predicted
-                #  - row 3 is the interaction
-                x = np.column_stack(
-                    (
-                        # de-standardize the previous output value
-                        standardize(
-                            proj[i],
-                            self.standards["previous"]["mean"],
-                            self.standards["previous"]["std"],
-                        ),
-                        standardize(
-                            self.incident_projection["elapsed"][i],
-                            self.standards["elapsed"]["mean"],
-                            self.standards["elapsed"]["mean"],
-                        ),
-                    )
-                )
-                x = np.insert(x, 2, np.array((x[:, 0] * x[:, 1])), axis=1)
-                # use the fitted linear model to predict the value for the next (i+1)
-                # forecast value, and then de-standardize
-                y = self.model.predict(x)
-                proj[i + 1] = unstandardize(
-                    y[(0, 0)],
-                    self.standards["daily"]["mean"],
-                    self.standards["daily"]["std"],
-                )
-                # in the first iteration, the "daily" value to be fitted is the last
-                # value from the training data. in other iterations, it is the predicted
-                # value from the iteration before.
-
-            # after done iterating over the prediction times:
-            # assign the rows in the output data frame that are for this region
-            # but drop the last row(?) in `proj`, which was initialized with value
-            # zero but not updated
-            self.incident_projection = self.incident_projection.with_columns(
-                daily=pl.when(pl.col("region") == self.start["region"][r])
-                .then(pl.Series(np.delete(proj, 0)))
-                .otherwise(pl.col("daily"))
-            )
-
-        # add estimate, which is the estimated uptake rate times the duration of the
-        # uptake period
-        self.incident_projection = self.incident_projection.with_columns(
-            estimate=pl.col("daily") * pl.col("interval")
-        )
+        self.incident_projection = self.incident_projection.group_by(
+            self.group_vars
+        ).map_groups(self._predict1)
 
         self.incident_projection = IncidentUptakeData(self.incident_projection)
 

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -618,6 +618,11 @@ class LinearIncidentUptakeModel(UptakeModel):
 
         self.y = data.select(["daily_std"]).to_numpy()
 
+        # linear model is fit on inputs:
+        # 1. previous uptake rate ("last daily")
+        # 2. time from rollout to end of this predicted uptake period ("elapsed")
+        # 3. interaction between the two terms
+        # and it returns: uptake rate ("daily") in this period
         self.model.fit(self.x, self.y)
 
         return self


### PR DESCRIPTION
- Trim outliers and compute "elapsed" using `.over()` or with `.map_groups()`
- Separate data frame augmentation into its own static method