### PR TITLE
Generalization for arbitrary grouping factors

### DIFF
--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -486,7 +486,7 @@ def extract_group_names(
         [g.get(v) == group_cols[0].get(v) for g, v in zip(group_cols, group_cols[0])]
     )
 
-    group_names = [v for v in group_cols[0].values()]
+    group_names = tuple([v for v in group_cols[0].values()])
 
     return group_names
 
@@ -729,7 +729,7 @@ class LinearIncidentUptakeModel(UptakeModel):
                 .with_columns(interval=pl.col("elapsed").diff().over(group_cols))
             )
             .join(
-                self.start.select([group_cols] + ["last_elapsed", "last_interval"]),
+                self.start.select(list(group_cols) + ["last_elapsed", "last_interval"]),
                 on=group_cols,
             )
             .with_columns(
@@ -786,8 +786,8 @@ class LinearIncidentUptakeModel(UptakeModel):
         self.incident_projection = IncidentUptakeData(self.incident_projection)
 
         self.cumulative_projection = self.incident_projection.to_cumulative(
-            group_cols, self.start.select([group_cols] + ["last_cumulative"])
-        ).select([group_cols] + ["date", "estimate"])
+            group_cols, self.start.select(list(group_cols) + ["last_cumulative"])
+        ).select(list(group_cols) + ["date", "estimate"])
 
         self.cumulative_projection = CumulativeUptakeData(self.cumulative_projection)
 

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -497,7 +497,6 @@ def extract_group_names(
     """
 
     if None in group_cols:
-        # group_names = tuple([])
         group_names = None
     else:
         assert all([len(g) == len(group_cols[0]) for g in group_cols])

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -2,9 +2,10 @@
 data:
   data_set_1:
     path: PATH_TO_DATA_GOES_HERE
-    region_col: geography
-    date_col: date
     estimate_col: estimate
+    date_col: date
+    group_cols:
+      geography: region
     date_format: "%m/%d/%Y"
     rollout: 2023-09-01
     filters:

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -13,9 +13,7 @@ def run(config):
     )
 
     # List of incident data sets from the cumulative data sets
-    incident_data = [
-        x.to_incident(y) for x, y in zip(cumulative_data, grouping_factors)
-    ]
+    incident_data = [x.to_incident(grouping_factors) for x in cumulative_data]
 
     # Concatenate data sets and split into train and test subsets
     incident_train_data = iup.IncidentUptakeData.split_train_test(
@@ -25,12 +23,12 @@ def run(config):
     # Fit models using the training data and make projections
     incident_model = (
         iup.LinearIncidentUptakeModel()
-        .fit(incident_train_data, grouping_factors[0])
+        .fit(incident_train_data, grouping_factors)
         .predict(
             config["timeframe"]["start"],
             config["timeframe"]["end"],
             config["timeframe"]["interval"],
-            grouping_factors[0],
+            grouping_factors,
         )
     )
     print(incident_model.cumulative_projection)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -7,31 +7,30 @@ def run(config):
     # List of the cumulative data sets described in the yaml
     cumulative_data = [iup.parse_nis(**x) for x in config["data"].values()]
 
+    # List of grouping factors used in each data set
+    grouping_factors = iup.extract_group_names(
+        [x["group_cols"] for x in config["data"].values()]
+    )
+
     # List of incident data sets from the cumulative data sets
-    incident_data = [x.to_incident() for x in cumulative_data]
+    incident_data = [
+        x.to_incident(y) for x, y in zip(cumulative_data, grouping_factors)
+    ]
 
     # Concatenate data sets and split into train and test subsets
-    # cumulative_train_data = iup.CumulativeUptakeData.split_train_test(
-    #    cumulative_data, config["timeframe"]["start"], "train"
-    # )
-    # cumulative_test_data = iup.CumulativeUptakeData.split_train_test(
-    #    cumulative_data, config["timeframe"]["start"], "test"
-    # )
     incident_train_data = iup.IncidentUptakeData.split_train_test(
         incident_data, config["timeframe"]["start"], "train"
     )
-    # incident_test_data = iup.IncidentUptakeData.split_train_test(
-    #    incident_data, config["timeframe"]["start"], "test"
-    # )
 
     # Fit models using the training data and make projections
     incident_model = (
         iup.LinearIncidentUptakeModel()
-        .fit(incident_train_data)
+        .fit(incident_train_data, grouping_factors[0])
         .predict(
             config["timeframe"]["start"],
             config["timeframe"]["end"],
             config["timeframe"]["interval"],
+            grouping_factors[0],
         )
     )
     print(incident_model.cumulative_projection)


### PR DESCRIPTION
This uses the .over() approach to accommodate arbitrary grouping factors. The user now specifies in the config .yaml file which grouping factors to use from each data set, giving both the names of the relevant NIS columns as well as the desired names for these columns. The desired names for the grouping factor columns ought to match across any data sets that will be pooled together into the same model. A new function `extract_group_names` verifies this.

This PR does NOT include any testing - I will save that for later. 

So, please ignore PRs #49, #50, and #51. These should be kept a little while longer for reference, but not merged. This PR is the one that should be thoroughly reviewed and merged to permit arbitrary grouping factors.