### PR TITLE
Refactor data type and forecast type

### DIFF
--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -1021,9 +1021,11 @@ class QuantileForecast(ValidatedData):
 
     # Must be named as "quantileXX" except the date column
     def validate(self):
+        # has at least 1 column of date and 1 column of estimate
         self.assert_type_included(pl.Date)
         self.assert_type_included(pl.Float64)
-        # has at least 1 column of date and 1 column of estimate
+
+        # except date, must have the common column names
         estimate = self.select(pl.all().exclude(pl.Date))
         super().assert_column_name_all(estimate, "quantile")
 
@@ -1053,6 +1055,11 @@ class SampleForecast(ValidatedData):
         super().__init__(*args, **kwargs)
 
     def validate(self):
+        # has at least 1 column of date and 1 column of estimate
+        self.assert_type_included(pl.Date)
+        self.assert_type_included(pl.Float64)
+
+        # except date, must have the common column names
         estimate = self.select(pl.all().exclude(pl.Date))
         super().assert_column_name_all(estimate, "sample_id")
 

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -75,18 +75,16 @@ class ValidatedUptake(pl.DataFrame):
         result = super().with_columns(*args, **kwargs)
         return orig_class(result)
 
-    @staticmethod
-    def assert_column_name_all(estimate, column_name):
+    def assert_column_name_all(self, column_name):
         """
-        Verify that all columns have a pattern with a common name
+        Verify that all columns except 'date' have a pattern with a common name
 
         Parameters
-        estimate:
-            The data without 'date' type
         column_name:
             The common column name
         """
-        pattern = rf"^{column_name}\d+$"
+        estimate = self.select(pl.all().exclude(pl.Date))
+        pattern = rf"^{column_name}\d*$"
         assert all(
             [bool(re.match(pattern, col)) for col in estimate.columns]
         ), f"Not all columns are Column name {column_name}"
@@ -1026,8 +1024,7 @@ class QuantileForecast(ValidatedUptake):
         self.assert_type_included(pl.Float64)
 
         # except date, must have the common column names
-        estimate = self.select(pl.all().exclude(pl.Date))
-        super().assert_column_name_all(estimate, "quantile")
+        super().assert_column_name_all("quantile")
 
 
 class PointForecast(QuantileForecast):
@@ -1060,8 +1057,7 @@ class SampleForecast(ValidatedUptake):
         self.assert_type_included(pl.Float64)
 
         # except date, must have the common column names
-        estimate = self.select(pl.all().exclude(pl.Date))
-        super().assert_column_name_all(estimate, "sample_id")
+        super().assert_column_name_all("sample_id")
 
 
 ###### evaluation metrics #####

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -8,7 +8,7 @@ from typing import List
 import re
 
 
-class ValidatedData(pl.DataFrame):
+class ValidatedUptake(pl.DataFrame):
     """
     Abstract class for observed data and forecast data.
     """
@@ -19,7 +19,7 @@ class ValidatedData(pl.DataFrame):
 
     def validate(self):
         """
-        Validate that an ValidatedData object has the two key columns:
+        Validate that an ValidatedUptake object has the two key columns:
         date and uptake estimate (% of population). There may be others.
         """
 
@@ -162,10 +162,10 @@ class ValidatedData(pl.DataFrame):
     @staticmethod
     def split_train_test(uptake_data_list, start_date: dt.date, side: str):
         """
-        Concatenate ValidatedData objects and split into training and test data.
+        Concatenate ValidatedUptake objects and split into training and test data.
 
         Parameters
-        uptake_data_list: List[ValidatedData]
+        uptake_data_list: List[ValidatedUptake]
             cumulative or incident uptake data objects, often from different seasons
         start_date: dt.date
             the first date for which projections should be made
@@ -173,7 +173,7 @@ class ValidatedData(pl.DataFrame):
             whether the "train" or "test" portion of the data is desired
 
         Returns
-        ValidatedData
+        ValidatedUptake
             cumulative or uptake data object of the training or test portion
 
         Details
@@ -198,9 +198,9 @@ class ValidatedData(pl.DataFrame):
         return out
 
 
-class IncidentUptakeData(ValidatedData):
+class IncidentUptakeData(ValidatedUptake):
     """
-    Subclass of ValidatedData for incident uptake.
+    Subclass of ValidatedUptake for incident uptake.
     """
 
     def __init__(self, *args, **kwargs):
@@ -217,7 +217,7 @@ class IncidentUptakeData(ValidatedData):
           threshold (float): maximum standardized interval between first two dates
 
         Returns
-        IncidentValidatedData
+        IncidentValidatedUptake
             incident uptake data with the outlier rows removed
 
         Details
@@ -328,9 +328,9 @@ class IncidentUptakeData(ValidatedData):
         return out
 
 
-class CumulativeUptakeData(ValidatedData):
+class CumulativeUptakeData(ValidatedUptake):
     """
-    Subclass of ValidatedData for cumulative uptake.
+    Subclass of ValidatedUptake for cumulative uptake.
     """
 
     def to_incident(self, group_cols: tuple[str,] | None) -> IncidentUptakeData:
@@ -1010,7 +1010,7 @@ class LinearIncidentUptakeModel(UptakeModel):
 
 
 #### prediction output ####
-class QuantileForecast(ValidatedData):
+class QuantileForecast(ValidatedUptake):
     """
     Class for forecast with quantiles.
     Save for future.
@@ -1045,7 +1045,7 @@ class PointForecast(QuantileForecast):
         super().assert_columns_type(["estimate"], pl.Float64)
 
 
-class SampleForecast(ValidatedData):
+class SampleForecast(ValidatedUptake):
     """
     Class for forecast with posterior distribution.
     Save for future.

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -632,11 +632,11 @@ class UptakeModel(abc.ABC):
     """
 
     @abc.abstractmethod
-    def fit(self, data: UptakeData) -> Self:
+    def fit(self, data: IncidentUptakeData) -> Self:
         pass
 
     @abc.abstractmethod
-    def predict(self, data: UptakeData, *args, **kwargs) -> UptakeData:
+    def predict(self, data: IncidentUptakeData, *args, **kwargs) -> IncidentUptakeData:
         pass
 
 

--- a/tests/test_uptake_data.py
+++ b/tests/test_uptake_data.py
@@ -35,7 +35,7 @@ def test_date_to_season(frame):
     """
     Return the overwinter season, for both fall and spring dates
     """
-    output = frame.with_columns(date=iup.UptakeData.date_to_season(pl.col("date")))
+    output = frame.with_columns(date=iup.ValidatedData.date_to_season(pl.col("date")))
 
     assert all(output["date"] == pl.Series(["2019/2020"] * 8))
 
@@ -45,7 +45,7 @@ def test_date_to_interval(frame):
     Return the interval between dates by grouping factor
     """
     output = frame.with_columns(
-        interval=iup.UptakeData.date_to_interval(pl.col("date")).over("geography")
+        interval=iup.ValidatedData.date_to_interval(pl.col("date")).over("geography")
     )
 
     assert all(
@@ -68,7 +68,7 @@ def test_date_to_elapsed(frame):
     Return the time elapsed since the first date by grouping factor.
     """
     output = frame.with_columns(
-        elapsed=iup.UptakeData.date_to_elapsed(pl.col("date")).over("geography")
+        elapsed=iup.ValidatedData.date_to_elapsed(pl.col("date")).over("geography")
     )
 
     assert all(
@@ -95,7 +95,7 @@ def test_split_train_test_handles_train(frame):
     frame2 = frame.with_columns(date=pl.col("date") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
-    output = iup.UptakeData.split_train_test([frame, frame2], start_date, "train")
+    output = iup.ValidatedData.split_train_test([frame, frame2], start_date, "train")
 
     assert output.equals(frame)
 
@@ -107,7 +107,7 @@ def test_split_train_test_handles_test(frame):
     frame2 = frame.with_columns(date=pl.col("date") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
-    output = iup.UptakeData.split_train_test([frame, frame2], start_date, "test")
+    output = iup.ValidatedData.split_train_test([frame, frame2], start_date, "test")
 
     assert output.equals(frame2)
 

--- a/tests/test_uptake_data.py
+++ b/tests/test_uptake_data.py
@@ -35,7 +35,7 @@ def test_date_to_season(frame):
     """
     Return the overwinter season, for both fall and spring dates
     """
-    output = frame.with_columns(date=iup.ValidatedData.date_to_season(pl.col("date")))
+    output = frame.with_columns(date=iup.ValidatedUptake.date_to_season(pl.col("date")))
 
     assert all(output["date"] == pl.Series(["2019/2020"] * 8))
 
@@ -45,7 +45,7 @@ def test_date_to_interval(frame):
     Return the interval between dates by grouping factor
     """
     output = frame.with_columns(
-        interval=iup.ValidatedData.date_to_interval(pl.col("date")).over("geography")
+        interval=iup.ValidatedUptake.date_to_interval(pl.col("date")).over("geography")
     )
 
     assert all(
@@ -68,7 +68,7 @@ def test_date_to_elapsed(frame):
     Return the time elapsed since the first date by grouping factor.
     """
     output = frame.with_columns(
-        elapsed=iup.ValidatedData.date_to_elapsed(pl.col("date")).over("geography")
+        elapsed=iup.ValidatedUptake.date_to_elapsed(pl.col("date")).over("geography")
     )
 
     assert all(
@@ -95,7 +95,7 @@ def test_split_train_test_handles_train(frame):
     frame2 = frame.with_columns(date=pl.col("date") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
-    output = iup.ValidatedData.split_train_test([frame, frame2], start_date, "train")
+    output = iup.ValidatedUptake.split_train_test([frame, frame2], start_date, "train")
 
     assert output.equals(frame)
 
@@ -107,7 +107,7 @@ def test_split_train_test_handles_test(frame):
     frame2 = frame.with_columns(date=pl.col("date") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
-    output = iup.ValidatedData.split_train_test([frame, frame2], start_date, "test")
+    output = iup.ValidatedUptake.split_train_test([frame, frame2], start_date, "test")
 
     assert output.equals(frame2)
 


### PR DESCRIPTION
![module_component](https://github.com/user-attachments/assets/d9dcf9c1-13b0-4174-8675-37476f3af6be)
 
This PR deletes the intermediate classes between ValidatedData and the end data types for observed data (Incident/CumulativeUptakeData) and forecasts (Quantile/SampleForecast). Each class has slightly different validation methods. In this way, the ValidatedData is a pool of functions, where different functions are used by multiple subclasses. The pro of this architecture is it is clear and easy to understand, while the con is that some functions are not meaningful for some classes but they can still be called. This is explicit for `split_train_test` function, which should not be available for any forecast types. Maybe consider to put it under both Incident&CumulativeUptakeData. However, other functions like 'date_to_*' can be useful for forecast types as well. 

Another note is that, the outcome from `predict()` in the LinearIncidentUptakeModel should be PointForecast type to feed into metric function.

The UptakeData is replaced with ValidatedData in `test_uptake_data.py`, please correct if anything is done wrong!