### PR TITLE
Data refactor

### DIFF
--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -978,11 +978,13 @@ class QuantileForecast(Data):
 
     def validate(self):
         self.assert_in_schema(
-            [("date", pl.Date), ("quantile", pl.Float64), ("estimate", pl.Float64)]
+            {"date": pl.Date, "quantile": pl.Float64, "estimate": pl.Float64}
         )
 
         # all quantiles should be between 0 and 1
-        assert self["quantile"].is_between(0.0, 1.0).all()
+        assert (
+            self["quantile"].is_between(0.0, 1.0).all()
+        ), "quantiles must be between 0 and 1"
 
 
 class PointForecast(QuantileForecast):

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -28,11 +28,15 @@ class Data(pl.DataFrame):
         for name, type_ in names_types.items():
             if name not in self.schema.names():
                 raise RuntimeError(f"Column '{name}' not found")
-            elif (name, type_) not in self.schema.items():
+            elif (
+                name in self.schema.names() and (name, type_) not in self.schema.items()
+            ):
                 actual_type = self.schema.to_python()[name]
-                f"Column '{name}' has type {actual_type}, not {type_}"
-
-            assert (name, type_) in self.schema.items()
+                raise RuntimeError(
+                    f"Column '{name}' has type {actual_type}, not {type_}"
+                )
+            else:
+                assert (name, type_) in self.schema.items()
 
 
 class UptakeData(Data):
@@ -1009,7 +1013,7 @@ class SampleForecast(Data):
 
     def validate(self):
         self.assert_in_schema(
-            [("date", pl.Date), ("sample_id", pl.Int64), ("estimate", pl.Float64)]
+            {"date": pl.Date, "sample_id": pl.Int64, "estimate": pl.Float64}
         )
 
 

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -9,7 +9,7 @@ import re
 from polars import testing
 
 
-class ValidatedData(pl.DataFrame):
+class ValidatedUptake(pl.DataFrame):
     """
     Abstract class for observed data and forecast data.
     """
@@ -20,7 +20,7 @@ class ValidatedData(pl.DataFrame):
 
     def validate(self):
         """
-        Validate that an ValidatedData object has the two key columns:
+        Validate that an ValidatedUptake object has the two key columns:
         date and uptake estimate (% of population). There may be others.
         """
 
@@ -192,10 +192,10 @@ class ValidatedData(pl.DataFrame):
     @staticmethod
     def split_train_test(uptake_data_list, start_date: dt.date, side: str):
         """
-        Concatenate ValidatedData objects and split into training and test data.
+        Concatenate ValidatedUptake objects and split into training and test data.
 
         Parameters
-        uptake_data_list: List[ValidatedData]
+        uptake_data_list: List[ValidatedUptake]
             cumulative or incident uptake data objects, often from different seasons
         start_date: dt.date
             the first date for which projections should be made
@@ -203,7 +203,7 @@ class ValidatedData(pl.DataFrame):
             whether the "train" or "test" portion of the data is desired
 
         Returns
-        ValidatedData
+        ValidatedUptake
             cumulative or uptake data object of the training or test portion
 
         Details
@@ -228,9 +228,9 @@ class ValidatedData(pl.DataFrame):
         return out
 
 
-class IncidentUptakeData(ValidatedData):
+class IncidentUptakeData(ValidatedUptake):
     """
-    Subclass of ValidatedData for incident uptake.
+    Subclass of ValidatedUptake for incident uptake.
     """
 
     def __init__(self, *args, **kwargs):
@@ -247,7 +247,7 @@ class IncidentUptakeData(ValidatedData):
           threshold (float): maximum standardized interval between first two dates
 
         Returns
-        IncidentValidatedData
+        IncidentValidatedUptake
             incident uptake data with the outlier rows removed
 
         Details
@@ -358,9 +358,9 @@ class IncidentUptakeData(ValidatedData):
         return out
 
 
-class CumulativeUptakeData(ValidatedData):
+class CumulativeUptakeData(ValidatedUptake):
     """
-    Subclass of ValidatedData for cumulative uptake.
+    Subclass of ValidatedUptake for cumulative uptake.
     """
 
     def to_incident(self, group_cols: tuple[str,] | None) -> IncidentUptakeData:
@@ -1040,7 +1040,7 @@ class LinearIncidentUptakeModel(UptakeModel):
 
 
 #### prediction output ####
-class QuantileForecast(ValidatedData):
+class QuantileForecast(ValidatedUptake):
     """
     Class for forecast with quantiles.
     Save for future.
@@ -1075,7 +1075,7 @@ class PointForecast(QuantileForecast):
         super().assert_columns_type(["estimate"], pl.Float64)
 
 
-class SampleForecast(ValidatedData):
+class SampleForecast(ValidatedUptake):
     """
     Class for forecast with posterior distribution.
     Save for future.

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -1051,9 +1051,11 @@ class QuantileForecast(ValidatedData):
 
     # Must be named as "quantileXX" except the date column
     def validate(self):
+        # has at least 1 column of date and 1 column of estimate
         self.assert_type_included(pl.Date)
         self.assert_type_included(pl.Float64)
-        # has at least 1 column of date and 1 column of estimate
+
+        # except date, must have the common column names
         estimate = self.select(pl.all().exclude(pl.Date))
         super().assert_column_name_all(estimate, "quantile")
 
@@ -1083,6 +1085,11 @@ class SampleForecast(ValidatedData):
         super().__init__(*args, **kwargs)
 
     def validate(self):
+        # has at least 1 column of date and 1 column of estimate
+        self.assert_type_included(pl.Date)
+        self.assert_type_included(pl.Float64)
+
+        # except date, must have the common column names
         estimate = self.select(pl.all().exclude(pl.Date))
         super().assert_column_name_all(estimate, "sample_id")
 

--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -172,3 +172,11 @@ def test_quantile_forecast_validation():
         iup.QuantileForecast(
             {"quantile": [-0.1], "date": [dt.date(2020, 1, 1)], "estimate": [0.0]}
         )
+
+
+def test_sample_forecast_validation():
+    iup.SampleForecast(
+        pl.DataFrame(
+            {"date": [dt.date(2020, 1, 1)], "estimate": [0.0], "sample_id": 0}
+        ).with_columns(pl.col("sample_id").cast(pl.Int64))
+    )

--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -165,3 +165,10 @@ def test_extract_group_names_handles_no_groups():
     output = iup.extract_group_names(group_cols)
 
     assert output is None
+
+
+def test_quantile_forecast_validation():
+    with pytest.raises(AssertionError, match="quantile"):
+        iup.QuantileForecast(
+            {"quantile": [-0.1], "date": [dt.date(2020, 1, 1)], "estimate": [0.0]}
+        )

--- a/tests/test_model_building.py
+++ b/tests/test_model_building.py
@@ -84,10 +84,10 @@ def test_fit(frame):
     Model should fit a line to two points, giving a 'perfect' fit
     """
 
-    output = iup.LinearIncidentUptakeModel()
-    output = output.fit(frame, ("geography",))
+    data = iup.IncidentUptakeData(frame)
+    model = iup.LinearIncidentUptakeModel().fit(data, ("geography",))
 
-    assert output.model.score(output.x, output.y) == 1.0
+    assert model.model.score(model.x, model.y) == 1.0
 
 
 def test_build_scaffold_handles_no_groups():

--- a/tests/test_uptake_data.py
+++ b/tests/test_uptake_data.py
@@ -35,7 +35,7 @@ def test_date_to_season(frame):
     """
     Return the overwinter season, for both fall and spring dates
     """
-    output = frame.with_columns(date=iup.ValidatedUptake.date_to_season(pl.col("date")))
+    output = frame.with_columns(date=iup.ValidatedData.date_to_season(pl.col("date")))
 
     assert all(output["date"] == pl.Series(["2019/2020"] * 8))
 
@@ -45,7 +45,7 @@ def test_date_to_interval(frame):
     Return the interval between dates by grouping factor
     """
     output = frame.with_columns(
-        interval=iup.ValidatedUptake.date_to_interval(pl.col("date")).over("geography")
+        interval=iup.ValidatedData.date_to_interval(pl.col("date")).over("geography")
     )
 
     assert all(
@@ -68,7 +68,7 @@ def test_date_to_elapsed(frame):
     Return the time elapsed since the first date by grouping factor.
     """
     output = frame.with_columns(
-        elapsed=iup.ValidatedUptake.date_to_elapsed(pl.col("date")).over("geography")
+        elapsed=iup.ValidatedData.date_to_elapsed(pl.col("date")).over("geography")
     )
 
     assert all(
@@ -95,7 +95,7 @@ def test_split_train_test_handles_train(frame):
     frame2 = frame.with_columns(date=pl.col("date") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
-    output = iup.ValidatedUptake.split_train_test([frame, frame2], start_date, "train")
+    output = iup.ValidatedData.split_train_test([frame, frame2], start_date, "train")
 
     assert output.equals(frame)
 
@@ -107,7 +107,7 @@ def test_split_train_test_handles_test(frame):
     frame2 = frame.with_columns(date=pl.col("date") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
-    output = iup.ValidatedUptake.split_train_test([frame, frame2], start_date, "test")
+    output = iup.ValidatedData.split_train_test([frame, frame2], start_date, "test")
 
     assert output.equals(frame2)
 

--- a/tests/test_uptake_data.py
+++ b/tests/test_uptake_data.py
@@ -5,7 +5,7 @@ import datetime as dt
 
 
 @pytest.fixture
-def frame():
+def frame() -> iup.UptakeData:
     """
     Make a mock data frame to uptake data manipulations.
     """
@@ -26,16 +26,16 @@ def frame():
         }
     )
 
-    frame = frame.with_columns(date=pl.col("date").str.strptime(pl.Date, "%Y-%m-%d"))
+    frame = frame.with_columns(date=pl.col("date").str.to_date("%Y-%m-%d"))
 
-    return frame
+    return iup.UptakeData(frame)
 
 
 def test_date_to_season(frame):
     """
     Return the overwinter season, for both fall and spring dates
     """
-    output = frame.with_columns(date=iup.ValidatedData.date_to_season(pl.col("date")))
+    output = frame.with_columns(date=iup.UptakeData.date_to_season(pl.col("date")))
 
     assert all(output["date"] == pl.Series(["2019/2020"] * 8))
 
@@ -45,7 +45,7 @@ def test_date_to_interval(frame):
     Return the interval between dates by grouping factor
     """
     output = frame.with_columns(
-        interval=iup.ValidatedData.date_to_interval(pl.col("date")).over("geography")
+        interval=iup.UptakeData.date_to_interval(pl.col("date")).over("geography")
     )
 
     assert all(
@@ -68,7 +68,7 @@ def test_date_to_elapsed(frame):
     Return the time elapsed since the first date by grouping factor.
     """
     output = frame.with_columns(
-        elapsed=iup.ValidatedData.date_to_elapsed(pl.col("date")).over("geography")
+        elapsed=iup.UptakeData.date_to_elapsed(pl.col("date")).over("geography")
     )
 
     assert all(
@@ -95,7 +95,7 @@ def test_split_train_test_handles_train(frame):
     frame2 = frame.with_columns(date=pl.col("date") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
-    output = iup.ValidatedData.split_train_test([frame, frame2], start_date, "train")
+    output = iup.UptakeData.split_train_test([frame, frame2], start_date, "train")
 
     assert output.equals(frame)
 
@@ -107,7 +107,7 @@ def test_split_train_test_handles_test(frame):
     frame2 = frame.with_columns(date=pl.col("date") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
-    output = iup.ValidatedData.split_train_test([frame, frame2], start_date, "test")
+    output = iup.UptakeData.split_train_test([frame, frame2], start_date, "test")
 
     assert output.equals(frame2)
 
@@ -237,28 +237,26 @@ def test_to_cumulative_handles_no_groups(frame):
     assert all(output["estimate"] == pl.Series([0.0, 1.0, 4.0, 8.0]))
 
 
+def test_cumulative_uptake_is_proportion(frame):
+    # should have an error if cumulative uptake is >1
+    assert frame["estimate"].max() > 1.0
+    with pytest.raises(AssertionError, match="proportion"):
+        iup.CumulativeUptakeData(frame)
+
+    # should not have an error if not
+    iup.CumulativeUptakeData(frame.filter(pl.col("estimate") <= 1.0))
+
+
 def test_to_incident_handles_groups(frame):
     """
     If there are groups, successive differences are taken over the groups.
     """
-    frame = iup.CumulativeUptakeData(frame)
+    frame = iup.CumulativeUptakeData(frame.filter(pl.col("estimate") <= 1.0))
 
     output = frame.to_incident(group_cols=("geography",))
 
     assert all(
-        output["estimate"].round(10)
-        == pl.Series(
-            [
-                0.0,
-                0.0,
-                1.0,
-                0.1,
-                2.0,
-                0.2,
-                1.0,
-                0.1,
-            ]
-        )
+        output["estimate"].round(10) == pl.Series([0.0, 0.0, 1.0, 0.1, 0.2, 0.1])
     )
 
 
@@ -267,19 +265,11 @@ def test_to_incident_handles_no_groups(frame):
     If there are no groups, successive differences are taken over the entire data frame.
     """
     frame = iup.CumulativeUptakeData(
-        frame.filter(pl.col("geography") == "USA").drop("geography")
+        frame.filter(pl.col("geography") == "USA", pl.col("estimate") <= 1.0).drop(
+            "geography"
+        )
     )
 
     output = frame.to_incident(group_cols=None)
 
-    assert all(
-        output["estimate"].round(10)
-        == pl.Series(
-            [
-                0.0,
-                1.0,
-                2.0,
-                1.0,
-            ]
-        )
-    )
+    assert all(output["estimate"].round(10) == pl.Series([0.0, 1.0]))


### PR DESCRIPTION
- Rename the underlying data/forecast object as `Data`
- Simplify schema validations into a single method
- Add a validation that cumulative uptake estimates must be in [0, 1]
- Tweak tests to account for this new validation
- Methods on `Data` and its subclasses return normal `pl.DataFrame`s. Tweak one or two parts of the current uptake model to account for this.