### PR TITLE
Refactored Linear Incident Uptake Model to return projections separately, rather than as attributes

### DIFF
--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -1,6 +1,8 @@
 import polars as pl
 import datetime as dt
 from typing import Sequence
+from typing import List
+from polars.datatypes.classes import DataTypeClass
 
 
 class Data(pl.DataFrame):
@@ -15,7 +17,7 @@ class Data(pl.DataFrame):
     def validate(self):
         raise NotImplementedError("Subclasses must implement this method.")
 
-    def assert_in_schema(self, names_types: dict[str, pl.DataType]):
+    def assert_in_schema(self, names_types: dict[str, DataTypeClass]):
         """Verify that column of the expected types are present in the data frame
 
         Args:
@@ -289,7 +291,7 @@ def select_columns(
 
     frame = (
         frame.with_columns(
-            estimate=pl.col(estimate_col).cast(pl.Float64, strict=False),
+            estimate=pl.col(estimate_col).cast(pl.Float64, strict=False) / 100.0,
             date=pl.col(date_col).str.to_date(date_format),
         )
         .drop_nulls(subset=["estimate"])
@@ -335,7 +337,7 @@ def insert_rollout(
 
 
 def extract_group_names(
-    group_cols: Sequence[dict],
+    group_cols: List[dict],
 ) -> tuple[str,] | None:
     """
     Insure that the column names for grouping factors match across data sets.

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,5 +1,6 @@
 import yaml
 import iup
+from iup.models import LinearIncidentUptakeModel
 import argparse
 
 
@@ -16,22 +17,25 @@ def run(config):
     incident_data = [x.to_incident(grouping_factors) for x in cumulative_data]
 
     # Concatenate data sets and split into train and test subsets
-    incident_train_data = iup.IncidentUptakeData.split_train_test(
-        incident_data, config["timeframe"]["start"], "train"
+    incident_train_data = iup.IncidentUptakeData(
+        iup.IncidentUptakeData.split_train_test(
+            incident_data, config["timeframe"]["start"], "train"
+        )
     )
 
     # Fit models using the training data and make projections
-    incident_model = (
-        iup.LinearIncidentUptakeModel()
-        .fit(incident_train_data, grouping_factors)
-        .predict(
-            config["timeframe"]["start"],
-            config["timeframe"]["end"],
-            config["timeframe"]["interval"],
-            grouping_factors,
-        )
+    incident_model = LinearIncidentUptakeModel().fit(
+        incident_train_data, grouping_factors
     )
-    print(incident_model.cumulative_projection)
+    cumulative_projections = incident_model.predict(
+        config["timeframe"]["start"],
+        config["timeframe"]["end"],
+        config["timeframe"]["interval"],
+        grouping_factors,
+    )
+    print(cumulative_projections)
+    incident_projections = cumulative_projections.to_incident(grouping_factors)
+    print(incident_projections)
 
 
 if __name__ == "__main__":

--- a/tests/test_linear_incident_uptake_model.py
+++ b/tests/test_linear_incident_uptake_model.py
@@ -174,9 +174,8 @@ def test_trim_outlier_intervals_handles_two_rows(frame):
     """
     frame = iup.IncidentUptakeData(frame.filter(pl.col("date") < dt.date(2020, 1, 9)))
 
-    output = frame.pipe(
-        iup.models.LinearIncidentUptakeModel.trim_outlier_intervals,
-        group_cols=("geography",),
+    output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
+        frame, group_cols=("geography",)
     )
 
     assert output.shape[0] == 0
@@ -207,9 +206,8 @@ def test_trim_outlier_intervals_handles_above_threshold():
         .pipe(iup.IncidentUptakeData)
     )
 
-    output = df.pipe(
-        iup.models.LinearIncidentUptakeModel.trim_outlier_intervals,
-        group_cols=("geography",),
+    output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
+        df, group_cols=("geography",)
     )
 
     # should drop the first 3 rows, leaving only Jan 21
@@ -224,10 +222,8 @@ def test_trim_outlier_intervals_handles_below_threshold(frame):
     """
     frame = iup.IncidentUptakeData(frame)
 
-    output = frame.pipe(
-        iup.models.LinearIncidentUptakeModel.trim_outlier_intervals,
-        group_cols=("geography",),
-        threshold=2,
+    output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
+        frame, group_cols=("geography",), threshold=2
     )
 
     assert output.shape[0] == 4
@@ -240,9 +236,8 @@ def test_trim_outlier_intervals_handles_zero_std(frame):
     frame = frame.filter(pl.col("date") > dt.date(2020, 1, 1))
     frame = iup.IncidentUptakeData(frame)
 
-    output = frame.pipe(
-        iup.models.LinearIncidentUptakeModel.trim_outlier_intervals,
-        group_cols=("geography",),
+    output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
+        frame, group_cols=("geography",)
     )
 
     assert output.shape[0] == 2
@@ -253,9 +248,8 @@ def test_augment_implicit_columns(frame):
     Add 5 columns to the incident uptake data without losing any rows
     """
     frame = iup.IncidentUptakeData(frame)
-    frame = frame.pipe(
-        iup.models.LinearIncidentUptakeModel.augment_implicit_columns,
-        group_cols=("geography",),
+    frame = iup.models.LinearIncidentUptakeModel.augment_implicit_columns(
+        frame, group_cols=("geography",)
     )
 
     assert frame.shape[0] == 8
@@ -273,17 +267,7 @@ def test_date_to_season(frame):
     assert all(output["date"] == pl.Series(["2019/2020"] * 8))
 
 
-def test_date_to_interval():
-    dates = pl.Series(
-        [dt.date(2024, 12, 1), dt.date(2024, 12, 3), dt.date(2024, 12, 1)]
-    )
-    current = iup.models.LinearIncidentUptakeModel.date_to_interval(dates).to_list()
-    expected = [None, 2.0, -2.0]
-
-    assert current == expected
-
-
-def test_date_to_interval_df(frame):
+def test_date_to_interval(frame):
     """
     Return the interval between dates by grouping factor
     """


### PR DESCRIPTION
Note that the LinearIncidentUptakeModel must return cumulative projections. The reason is that if projections begin mid-season, cumulative projections will include the uptake that is already known, but incident projections won't. So cumulative projections are returned, and from there they can be converted to incident (as shown in the main.py script).

I also fixed a few issues in the current main branch that Pylance flagged on my local machine.

Resolves #31 