### PR TITLE
Update ruff pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,30 @@
 repos:
-#####
-# Basic file cleanliness
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+  #####
+  # Basic file cleanliness
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
     hooks:
-    -   id: check-added-large-files
-    -   id: check-yaml
-        args: ['--unsafe']
-    -   id: check-toml
-    -   id: end-of-file-fixer
-    -   id: mixed-line-ending
-    -   id: trailing-whitespace
-#####
-# Python
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.0
-  hooks:
-    - id: ruff
-#####
-# Secrets
--   repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+      - id: check-added-large-files
+      - id: check-yaml
+        args: ["--unsafe"]
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  #####
+  # Python
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.2
     hooks:
-    -   id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+      - id: ruff
+        args: ["check", "--select", "I", "--fix"]
+      - id: ruff
+      - id: ruff-format
+  #####
+  # Secrets
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
         exclude: package.lock.json

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -4,8 +4,6 @@ from typing import List, Sequence
 import polars as pl
 from polars.datatypes.classes import DataTypeClass
 
-import polars as pl
-
 
 class Data(pl.DataFrame):
     """

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -4,6 +4,8 @@ from typing import List, Sequence
 import polars as pl
 from polars.datatypes.classes import DataTypeClass
 
+import polars as pl
+
 
 class Data(pl.DataFrame):
     """

--- a/iup/eval.py
+++ b/iup/eval.py
@@ -1,6 +1,8 @@
-import polars as pl
-from iup import IncidentUptakeData, PointForecast
 from typing import Callable
+
+import polars as pl
+
+from iup import IncidentUptakeData, PointForecast
 
 
 ###### evaluation metrics #####

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,9 +1,11 @@
-import polars as pl
+from datetime import date
+
 import numpy as np
+import polars as pl
+import pytest
+
 import iup
 from iup import eval
-import pytest
-from datetime import date
 
 
 @pytest.fixture

--- a/tests/test_linear_incident_uptake_model.py
+++ b/tests/test_linear_incident_uptake_model.py
@@ -1,11 +1,13 @@
-import iup
-import iup.models
+import datetime as dt
+
+import numpy as np
 import polars as pl
 import polars.testing
 import pytest
-import datetime as dt
 from sklearn.linear_model import LinearRegression
-import numpy as np
+
+import iup
+import iup.models
 
 
 @pytest.fixture

--- a/tests/test_uptake_data.py
+++ b/tests/test_uptake_data.py
@@ -1,7 +1,9 @@
-import iup
+import datetime as dt
+
 import polars as pl
 import pytest
-import datetime as dt
+
+import iup
 
 
 @pytest.fixture


### PR DESCRIPTION
To harmonize with https://github.com/cdcent/cfa-repo-template/pull/38

The `ruff check` hook does what we used to use [isort](https://pycqa.github.io/isort/) to do

See https://github.com/cdcent/cfa-predict-handbook/pull/339/files for how to get VSCode to do this work automatically on save, so that pre-commit and VSCode are doing the same thing