### PR TITLE
Adjustments to insure compatibility with NIS API

### DIFF
--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -223,7 +223,8 @@ class CumulativeUptakeData(UptakeData):
                 .with_columns(
                     min=(pl.col("estimate") - pl.min("estimate")).over((group_cols))
                 )
-                .filter(pl.col("time_end").first().over(group_cols))
+                .group_by(group_cols)
+                .first()
             )["min"]
             == 0
         ).all()

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -100,10 +100,10 @@ class UptakeData(Data):
         Assume overwinter seasons, e.g. 2023-10-07 and 2024-04-18 are both in "2023/24"
         """
         year1 = (
-            date_col.dt.year() + pl.when(date_col.dt.month() < 7).then(-1).otherwise(0)
+            date_col.dt.year() + pl.when(date_col.dt.month() < 9).then(-1).otherwise(0)
         ).cast(pl.Utf8)
         year2 = (
-            date_col.dt.year() + pl.when(date_col.dt.month() < 7).then(0).otherwise(1)
+            date_col.dt.year() + pl.when(date_col.dt.month() < 9).then(0).otherwise(1)
         ).cast(pl.Utf8)
         season = pl.concat_str([year1, year2], separator="/")
 
@@ -221,12 +221,12 @@ class CumulativeUptakeData(UptakeData):
                     season=pl.col("time_end").pipe(UptakeData.date_to_season)
                 )
                 .with_columns(
-                    min=(pl.col("estimate") - pl.min("estimate")).over((group_cols))
+                    min=(pl.col("estimate") - pl.min("estimate")).over(group_cols)
                 )
                 .group_by(group_cols)
                 .first()
             )["min"]
-            == 0
+            == 0.0
         ).all()
 
         return frame

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -190,32 +190,27 @@ def insert_rollout(
 
 
 def extract_group_names(
-    group_cols: List[dict],
-) -> tuple[str,] | None:
+    group_cols: List[List[str]],
+) -> tuple | None:
     """
-    Insure that the column names for grouping factors match across data sets.
+    Note the column names for grouping factors across data sets.
 
     Parameters
-    group_cols: [dict,]
-        List of dictionaries of grouping factor column names, where
-        keys are the NIS column names and values are the desired column names
+    group_cols: [[str,]]
+        List of lists of column names for grouping factors, for each data set
 
     Returns
         (str,)
-        The desired column names
+        The column names of grouping factors common to all data sets
 
     Details
     Before returning a single tuple of the desired column names,
-    check that they are identical for every entry in the dictionary,
-    where each entry represents one data set.
+    check that they are identical for every data set.
     """
 
-    if None in group_cols:
-        group_names = None
-    else:
-        assert all([len(g) == len(group_cols[0]) for g in group_cols])
-        assert all([set(g.values()) == set(group_cols[0].values()) for g in group_cols])
-        group_names = tuple([v for v in group_cols[0].values()])
+    assert all([len(g) == len(group_cols[0]) for g in group_cols])
+    assert all([g == group_cols[0] for g in group_cols])
+    group_names = tuple(group_cols[0])
 
     return group_names
 

--- a/iup/eval.py
+++ b/iup/eval.py
@@ -23,15 +23,15 @@ def check_date_match(data: IncidentUptakeData, pred: PointForecast):
 
     """
     # sort data and pred by date #
-    data = IncidentUptakeData(data.sort("date"))
-    pred = PointForecast(pred.sort("date"))
+    data = IncidentUptakeData(data.sort("time_end"))
+    pred = PointForecast(pred.sort("time_end"))
 
     # 1. Dates must be 1-on-1 equal
-    (data["date"] == pred["date"]).all()
+    (data["time_end"] == pred["time_end"]).all()
 
     # 2. There should not be any duplicated date in either data or prediction.
     assert (
-        len(data["date"]) == data["date"].n_unique()
+        len(data["time_end"]) == data["time_end"].n_unique()
     ), "Duplicated dates are found in data and prediction."
 
 
@@ -62,12 +62,12 @@ def score(
     check_date_match(data, pred)
 
     return (
-        data.join(pred, on="date", how="inner", validate="1:1")
+        data.join(pred, on="time_end", how="inner", validate="1:1")
         .rename({"estimate": "data", "estimate_right": "pred"})
         .select(
-            forecast_start=pl.col("date").min(),
-            forecast_end=pl.col("date").max(),
-            score=score_fun(pl.col("data"), pl.col("pred")),
+            forecast_start=pl.col("time_end").min(),
+            forecast_end=pl.col("time_end").max(),
+            score=score_fun(pl.col("time_end"), pl.col("pred")),
         )
     )
 

--- a/iup/eval.py
+++ b/iup/eval.py
@@ -23,8 +23,8 @@ def check_date_match(data: IncidentUptakeData, pred: PointForecast):
 
     """
     # sort data and pred by date #
-    data = data.sort("date")
-    pred = pred.sort("date")
+    data = IncidentUptakeData(data.sort("date"))
+    pred = PointForecast(pred.sort("date"))
 
     # 1. Dates must be 1-on-1 equal
     (data["date"] == pred["date"]).all()

--- a/iup/eval.py
+++ b/iup/eval.py
@@ -67,7 +67,7 @@ def score(
         .select(
             forecast_start=pl.col("time_end").min(),
             forecast_end=pl.col("time_end").max(),
-            score=score_fun(pl.col("time_end"), pl.col("pred")),
+            score=score_fun(pl.col("data"), pl.col("pred")),
         )
     )
 

--- a/iup/models.py
+++ b/iup/models.py
@@ -605,38 +605,3 @@ class LinearIncidentUptakeModel(UptakeModel):
         Time difference is always in days.
         """
         return date_col.diff().dt.total_days().cast(pl.Float64)
-
-    @staticmethod
-    def insert_rollout(
-        frame: pl.DataFrame, rollout: dt.date, group_cols: dict | None
-    ) -> pl.DataFrame:
-        """
-        Insert into NIS uptake data rows with 0 uptake on the rollout date.
-
-        Parameters
-        frame: pl.DataFrame
-            NIS data in the midst of parsing
-        rollout: dt.date
-            rollout date
-        group_cols: dict | None
-            dictionary of the NIS columns for the grouping factors
-            keys are the NIS column names and values are the desired column names
-
-        Returns
-            NIS cumulative data with rollout rows included
-
-        Details
-        A separate rollout row is added for every grouping factor combination.
-        """
-        if group_cols is not None:
-            rollout_rows = (
-                frame.select(pl.col(v) for v in group_cols.values())
-                .unique()
-                .with_columns(date=rollout, estimate=0.0)
-            )
-        else:
-            rollout_rows = pl.DataFrame({"date": rollout, "estimate": 0.0})
-
-        frame = frame.vstack(rollout_rows.select(frame.columns)).sort("date")
-
-        return frame

--- a/iup/models.py
+++ b/iup/models.py
@@ -1,12 +1,13 @@
 import abc
 import datetime as dt
+from typing import List
 
 import numpy as np
 import polars as pl
 from sklearn.linear_model import LinearRegression
 from typing_extensions import Self
 
-from iup import CumulativeUptakeData, IncidentUptakeData
+from iup import CumulativeUptakeData, IncidentUptakeData, UptakeData
 
 
 class UptakeModel(abc.ABC):
@@ -41,7 +42,7 @@ class LinearIncidentUptakeModel(UptakeModel):
 
     @staticmethod
     def extract_starting_conditions(
-        data: IncidentUptakeData, group_cols: tuple[str,] | None
+        data: IncidentUptakeData, group_cols: List[str,] | None
     ) -> pl.DataFrame:
         """
         Extract from incident uptake data the last observed values of several variables, by group.
@@ -102,7 +103,7 @@ class LinearIncidentUptakeModel(UptakeModel):
 
         return standards
 
-    def fit(self, data: IncidentUptakeData, group_cols: tuple[str,] | None) -> Self:
+    def fit(self, data: IncidentUptakeData, group_cols: List[str,] | None) -> Self:
         """
         Fit a linear incident uptake model on training data.
 
@@ -223,7 +224,7 @@ class LinearIncidentUptakeModel(UptakeModel):
         start_date: dt.date,
         end_date: dt.date,
         interval: str,
-        group_cols: tuple[str,] | None,
+        group_cols: List[str,] | None,
     ) -> pl.DataFrame:
         """
         Build a scaffold data frame to hold projections of a linear incident uptake model.
@@ -292,7 +293,7 @@ class LinearIncidentUptakeModel(UptakeModel):
 
     @classmethod
     def augment_implicit_columns(
-        cls, df: IncidentUptakeData, group_cols: tuple[str,] | None
+        cls, df: IncidentUptakeData, group_cols: List[str,] | None
     ) -> pl.DataFrame:
         """
         Add explicit columns for information that is implicitly contained.
@@ -318,7 +319,7 @@ class LinearIncidentUptakeModel(UptakeModel):
         return (
             IncidentUptakeData(df)
             .with_columns(
-                season=pl.col("date").pipe(cls.date_to_season),
+                season=pl.col("date").pipe(UptakeData.date_to_season),
                 elapsed=pl.col("date").pipe(cls.date_to_elapsed).over(group_cols),
                 interval=pl.col("date").pipe(cls.date_to_interval).over(group_cols),
             )
@@ -344,32 +345,6 @@ class LinearIncidentUptakeModel(UptakeModel):
         Time difference is always in days.
         """
         return (date_col - date_col.first()).dt.total_days().cast(pl.Float64)
-
-    @staticmethod
-    def date_to_season(date_col: pl.Expr) -> pl.Expr:
-        """
-        Extract season column from a date column, as polars expressions.
-
-        Parameters
-        date_col: pl.Expr
-            column of dates
-
-        Returns
-        pl.Expr
-            column of the season for each date
-
-        Details
-        Assume overwinter seasons, e.g. 2023-10-07 and 2024-04-18 are both in "2023/24"
-        """
-        year1 = (
-            date_col.dt.year() + pl.when(date_col.dt.month() < 7).then(-1).otherwise(0)
-        ).cast(pl.Utf8)
-        year2 = (
-            date_col.dt.year() + pl.when(date_col.dt.month() < 7).then(0).otherwise(1)
-        ).cast(pl.Utf8)
-        season = pl.concat_str([year1, year2], separator="/")
-
-        return season
 
     @classmethod
     def project_sequentially(
@@ -452,7 +427,7 @@ class LinearIncidentUptakeModel(UptakeModel):
         start_date: dt.date,
         end_date: dt.date,
         interval: str,
-        group_cols: tuple[str,] | None,
+        group_cols: List[str,] | None,
     ) -> CumulativeUptakeData:
         """
         Make projections from a fit linear incident uptake model.
@@ -534,7 +509,7 @@ class LinearIncidentUptakeModel(UptakeModel):
     def trim_outlier_intervals(
         cls,
         df: IncidentUptakeData,
-        group_cols: tuple[str,] | None,
+        group_cols: List[str,] | None,
         threshold: float = 1.0,
     ) -> pl.DataFrame:
         """

--- a/iup/plot_projections.py
+++ b/iup/plot_projections.py
@@ -27,17 +27,17 @@ def plot_projections(obs_data, pred_data_list, n_columns, pic_loc, pic_name):
     """
 
     # input check #
-    if "date" not in obs_data.columns or "cumulative" not in obs_data.columns:
-        ValueError("'date' or 'cumulative' is missing from obs_data.")
+    if "time_end" not in obs_data.columns or "cumulative" not in obs_data.columns:
+        ValueError("'time_end' or 'cumulative' is missing from obs_data.")
 
     if not isinstance(pred_data_list, list):
         ValueError("pred_data_list must be a list.")
 
     if (
-        "date" not in pred_data_list[0].columns
+        "time_end" not in pred_data_list[0].columns
         or "cumulative" not in pred_data_list[0].columns
     ):
-        ValueError("'date' or 'cumulative' is missing from pred_data_list.")
+        ValueError("'time_end' or 'cumulative' is missing from pred_data_list.")
 
     # plot weekly initiated prediction #
     time_axis = alt.Axis(format="%Y-%m", tickCount="month")
@@ -45,12 +45,12 @@ def plot_projections(obs_data, pred_data_list, n_columns, pic_loc, pic_name):
     obs = (
         alt.Chart(obs_data)
         .mark_circle(color="black")
-        .encode(alt.X("date", axis=time_axis), alt.Y("cumulative"))
+        .encode(alt.X("time_end", axis=time_axis), alt.Y("cumulative"))
     )
 
     charts = []
 
-    dates = [pred_data_list[i]["date"].min() for i in range(len(pred_data_list))]
+    dates = [pred_data_list[i]["time_end"].min() for i in range(len(pred_data_list))]
 
     for i in range(len(pred_data_list)):
         date = dates[i].strftime("%Y-%m-%d")
@@ -60,7 +60,7 @@ def plot_projections(obs_data, pred_data_list, n_columns, pic_loc, pic_name):
             alt.Chart(pred)
             .mark_line(color="red")
             .encode(
-                x=alt.X("date:T", title="Date", axis=time_axis),
+                x=alt.X("time_end:T", title="Date", axis=time_axis),
                 y=alt.Y("cumulative:Q", title="Cumulative Vaccine Uptake (%)"),
             )
             .properties(title=f"Start Date: {date}")

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -13,7 +13,9 @@ data:
       geography: geography
       estimate: estimate
       time_end: date
-    group_cols: [geography]
+
+# Grouping factors across data sets
+groups: [geography]
 
 # The timeframe over which to generate projections
 timeframe:

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -12,7 +12,7 @@ data:
     keep:
       geography: geography
       estimate: estimate
-      time_end: date
+      time_end: time_end
 
 # Grouping factors across data sets
 groups: [geography]

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -9,10 +9,9 @@ data:
       indicator_type: 4-level vaccination and intent
       indicator: received a vaccination
       time_type: week
-    keep:
-      geography: geography
-      estimate: estimate
-      time_end: time_end
+
+# Columns to keep from each data set
+keep: ["geography", "estimate", "time_end"]
 
 # Grouping factors across data sets
 groups: [geography]

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -11,7 +11,7 @@ data:
       time_type: week
 
 # Columns to keep from each data set
-keep: ["geography", "estimate", "time_end"]
+keep: [geography, estimate, time_end]
 
 # Grouping factors across data sets
 groups: [geography]

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -1,15 +1,19 @@
 # The data sets to load and how to interpret them
 data:
   data_set_1:
-    group_cols:
-      geography: region
-    rollout: 2023-09-01
+    rollout: [2023-09-01, 2024-09-01]
     filters:
       geography_type: nation
       domain_type: age
       domain: 18+ years
       indicator_type: 4-level vaccination and intent
       indicator: received a vaccination
+      time_type: week
+    keep:
+      geography: geography
+      estimate: estimate
+      time_end: date
+    group_cols: [geography]
 
 # The timeframe over which to generate projections
 timeframe:

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -11,10 +11,6 @@ def run(config: dict, cache: str):
     # Get uptake data from the cache
     data = nisapi.get_nis(cache)
 
-    print(data.head().collect())
-    print(data.collect_schema().names())
-    print(data.collect().shape)
-
     # Prune data to correct rows and columns
     cumulative_data = [
         iup.CumulativeUptakeData(
@@ -27,16 +23,10 @@ def run(config: dict, cache: str):
         for x in config["data"].values()
     ]
 
-    print(cumulative_data[0].head())
-    print(cumulative_data[0].columns)
-    print(cumulative_data[0].shape)
-
     # Find grouping factors common to all data sets
     grouping_factors = iup.extract_group_names(
         [x["group_cols"] for x in config["data"].values()]
     )
-
-    print(grouping_factors)
 
     # Insert rollout dates into the data
     cumulative_data = [

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -16,14 +16,14 @@ def run(config: dict, cache: str):
         iup.CumulativeUptakeData(
             data.filter(**x["filters"])
             .collect()
-            .select(config["keep"].values())
+            .select(config["keep"])
             .sort("time_end")
         )
         for x in config["data"].values()
     ]
 
     # Insure that the desired grouping factors are found in all data sets
-    grouping_factors = config["groups"].values()
+    grouping_factors = config["groups"]
     assert all(g in df.columns for g in grouping_factors for df in cumulative_data)
 
     # Insert rollout dates into the data

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -18,7 +18,7 @@ def run(config: dict, cache: str):
             .collect()
             .rename(x["keep"])
             .select(x["keep"].values())
-            .sort("date")
+            .sort("time_end")
         )
         for x in config["data"].values()
     ]

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -10,13 +10,24 @@ from iup.models import LinearIncidentUptakeModel
 def run(config: dict, cache: str):
     data = nisapi.get_nis(cache)
 
-    # List of the cumulative data sets described in the yaml
-    # note that df.filter(**{"column1": value1, "column2": value2}) is equivalent to
-    # df.filter(pl.col("column1")==value1, pl.col("column2")==value2)
+    print(data.head().collect())
+    print(data.collect_schema().names())
+    print(data.collect().shape)
+
     cumulative_data = [
-        iup.CumulativeUptakeData(data.filter(**x["filters"]).collect())
+        iup.CumulativeUptakeData(
+            data.filter(**x["filters"])
+            .collect()
+            .rename(x["keep"])
+            .select(x["keep"].values())
+            .sort("date")
+        )
         for x in config["data"].values()
     ]
+
+    print(cumulative_data[0].head())
+    print(cumulative_data[0].columns)
+    print(cumulative_data[0].shape)
 
     # List of grouping factors used in each data set
     grouping_factors = iup.extract_group_names(

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -34,6 +34,8 @@ def run(config: dict, cache: str):
         [x["group_cols"] for x in config["data"].values()]
     )
 
+    print(grouping_factors)
+
     # List of incident data sets from the cumulative data sets
     incident_data = [x.to_incident(grouping_factors) for x in cumulative_data]
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -23,10 +23,9 @@ def run(config: dict, cache: str):
         for x in config["data"].values()
     ]
 
-    # Find grouping factors common to all data sets
-    grouping_factors = iup.extract_group_names(
-        [x["group_cols"] for x in config["data"].values()]
-    )
+    # Insure that the desired grouping factors are found in all data sets
+    grouping_factors = config["groups"].values()
+    assert all(g in df.columns for g in grouping_factors for df in cumulative_data)
 
     # Insert rollout dates into the data
     cumulative_data = [

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -16,8 +16,7 @@ def run(config: dict, cache: str):
         iup.CumulativeUptakeData(
             data.filter(**x["filters"])
             .collect()
-            .rename(x["keep"])
-            .select(x["keep"].values())
+            .select(config["keep"].values())
             .sort("time_end")
         )
         for x in config["data"].values()

--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -15,7 +15,7 @@ def frame():
     frame = pl.DataFrame(
         {
             "geography": ["USA", "PA", "USA"],
-            "date": ["2020-01-07", "2020-01-14", "2020-01-21"],
+            "time_end": ["2020-01-07", "2020-01-14", "2020-01-21"],
             "estimate": [0.0, 0.1, 0.2],
             "indicator": ["refused", "booster", "booster"],
         }
@@ -28,26 +28,34 @@ def test_insert_rollout_handles_groups(frame):
     """
     If grouping columns are given to insert_rollout, a separate rollout is inserted for each group.
     """
-    frame = frame.with_columns(date=pl.col("date").str.strptime(pl.Date, "%Y-%m-%d"))
+    frame = frame.with_columns(
+        date=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d")
+    )
     rollout = [dt.date(2020, 1, 1), dt.date(2021, 1, 1)]
-    group_cols = ("geography",)
+    group_cols = [
+        "geography",
+    ]
     frame = iup.CumulativeUptakeData(frame.drop("indicator"))
 
     output = frame.insert_rollout(rollout, group_cols)
 
     assert output.shape[0] == 7
     assert (
-        output["date"].value_counts().filter(pl.col("date") == rollout[0])["count"][0]
+        output["time_end"]
+        .value_counts()
+        .filter(pl.col("time_end") == rollout[0])["count"][0]
         == 2
     )
-    assert output["date"].is_sorted()
+    assert output["time_end"].is_sorted()
 
 
 def test_insert_rollout_handles_no_groups(frame):
     """
     If no grouping columns are given to insert_rollout, only one of each rollout is inserted.
     """
-    frame = frame.with_columns(date=pl.col("date").str.strptime(pl.Date, "%Y-%m-%d"))
+    frame = frame.with_columns(
+        date=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d")
+    )
     rollout = [dt.date(2020, 1, 1), dt.date(2021, 1, 1)]
     group_cols = None
     frame = iup.CumulativeUptakeData(frame.drop(["indicator", "geography"]))
@@ -56,53 +64,24 @@ def test_insert_rollout_handles_no_groups(frame):
 
     assert output.shape[0] == 5
     assert (
-        output["date"].value_counts().filter(pl.col("date") == rollout[0])["count"][0]
+        output["time_end"]
+        .value_counts()
+        .filter(pl.col("time_end") == rollout[0])["count"][0]
         == 1
     )
-    assert output["date"].is_sorted()
-
-
-def test_extract_group_names_handles_matched_groups():
-    """
-    If a list of identical group name lists is given, just one tuple is returned.
-    """
-    group_cols = [["geography", "indicator"], ["geography", "indicator"]]
-
-    output = iup.extract_group_names(group_cols)
-
-    assert output == ("geography", "indicator")
-
-
-def test_extract_group_names_handles_unmatched_groups():
-    """
-    If a list of non-identical group name lists is given, an error is raised.
-    """
-    group_cols = [["geography", "indicator"], ["geography", "mismatch"]]
-
-    with pytest.raises(AssertionError):
-        iup.extract_group_names(group_cols)
-
-
-def test_extract_group_names_handles_no_groups():
-    """
-    If a list group name lists containing None is given, an error is raised.
-    """
-    group_cols = [[None], ["geography", "mismatch"]]
-
-    with pytest.raises(AssertionError):
-        iup.extract_group_names(group_cols)
+    assert output["time_end"].is_sorted()
 
 
 def test_quantile_forecast_validation():
     with pytest.raises(AssertionError, match="quantile"):
         iup.QuantileForecast(
-            {"quantile": [-0.1], "date": [dt.date(2020, 1, 1)], "estimate": [0.0]}
+            {"quantile": [-0.1], "time_end": [dt.date(2020, 1, 1)], "estimate": [0.0]}
         )
 
 
 def test_sample_forecast_validation():
     iup.SampleForecast(
         pl.DataFrame(
-            {"date": [dt.date(2020, 1, 1)], "estimate": [0.0], "sample_id": 0}
+            {"time_end": [dt.date(2020, 1, 1)], "estimate": [0.0], "sample_id": 0}
         ).with_columns(pl.col("sample_id").cast(pl.Int64))
     )

--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -29,7 +29,7 @@ def test_insert_rollout_handles_groups(frame):
     If grouping columns are given to insert_rollout, a separate rollout is inserted for each group.
     """
     frame = frame.with_columns(
-        date=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d")
+        time_end=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d")
     )
     rollout = [dt.date(2020, 1, 1), dt.date(2021, 1, 1)]
     group_cols = [
@@ -54,7 +54,7 @@ def test_insert_rollout_handles_no_groups(frame):
     If no grouping columns are given to insert_rollout, only one of each rollout is inserted.
     """
     frame = frame.with_columns(
-        date=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d")
+        time_end=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d")
     )
     rollout = [dt.date(2020, 1, 1), dt.date(2021, 1, 1)]
     group_cols = None

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -15,7 +15,7 @@ def data():
     """
     return pl.DataFrame(
         {
-            "date": pl.date_range(
+            "time_end": pl.date_range(
                 date(2020, 1, 1), date(2020, 1, 5), interval="1d", eager=True
             ),
             "estimate": [0.0, 0.1, 0.7, 0.4, 0.5],
@@ -30,7 +30,7 @@ def pred():
     """
     return pl.DataFrame(
         {
-            "date": pl.date_range(
+            "time_end": pl.date_range(
                 date(2020, 1, 1), date(2020, 1, 5), interval="1d", eager=True
             ),
             "estimate": [0.0, 0.2, 1.0, 0.6, 0.5],

--- a/tests/test_linear_incident_uptake_model.py
+++ b/tests/test_linear_incident_uptake_model.py
@@ -37,7 +37,7 @@ def frame():
         )
         .with_columns(daily=(pl.col("estimate") / pl.col("interval")).fill_null(0))
         .with_columns(previous=pl.col("daily").shift(1).over("geography"))
-        .with_columns(date=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d"))
+        .with_columns(time_end=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d"))
     )
 
     frame = iup.IncidentUptakeData(frame)

--- a/tests/test_linear_incident_uptake_model.py
+++ b/tests/test_linear_incident_uptake_model.py
@@ -19,7 +19,7 @@ def frame():
         pl.DataFrame(
             {
                 "geography": ["USA", "PA", "USA", "PA", "USA", "PA", "USA", "PA"],
-                "date": [
+                "time_end": [
                     "2019-12-31",
                     "2019-12-31",
                     "2020-01-07",
@@ -37,7 +37,7 @@ def frame():
         )
         .with_columns(daily=(pl.col("estimate") / pl.col("interval")).fill_null(0))
         .with_columns(previous=pl.col("daily").shift(1).over("geography"))
-        .with_columns(date=pl.col("date").str.strptime(pl.Date, "%Y-%m-%d"))
+        .with_columns(date=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d"))
     )
 
     frame = iup.IncidentUptakeData(frame)
@@ -50,7 +50,10 @@ def test_extract_starting_conditions(frame):
     Use the last date for each grouping factor
     """
     output = iup.models.LinearIncidentUptakeModel.extract_starting_conditions(
-        frame, ("geography",)
+        frame,
+        [
+            "geography",
+        ],
     )
 
     assert output.sort("geography").equals(
@@ -89,7 +92,12 @@ def test_fit(frame):
     """
 
     data = iup.IncidentUptakeData(frame)
-    model = iup.models.LinearIncidentUptakeModel().fit(data, ("geography",))
+    model = iup.models.LinearIncidentUptakeModel().fit(
+        data,
+        [
+            "geography",
+        ],
+    )
 
     assert model.model.score(model.x, model.y) == 1.0
 
@@ -135,7 +143,9 @@ def test_build_scaffold_handles_groups():
     start_date = dt.date(2020, 2, 1)
     end_date = dt.date(2020, 2, 29)
     interval = "7d"
-    group_cols = ("geography",)
+    group_cols = [
+        "geography",
+    ]
 
     output = iup.models.LinearIncidentUptakeModel.build_scaffold(
         start, start_date, end_date, interval, group_cols
@@ -174,10 +184,15 @@ def test_trim_outlier_intervals_handles_two_rows(frame):
     """
     If there are two or fewer rows (per group), all rows should be trimmed.
     """
-    frame = iup.IncidentUptakeData(frame.filter(pl.col("date") < dt.date(2020, 1, 9)))
+    frame = iup.IncidentUptakeData(
+        frame.filter(pl.col("time_end") < dt.date(2020, 1, 9))
+    )
 
     output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
-        frame, group_cols=("geography",)
+        frame,
+        group_cols=[
+            "geography",
+        ],
     )
 
     assert output.shape[0] == 0
@@ -187,12 +202,11 @@ def test_trim_outlier_intervals_handles_above_threshold():
     """
     If the first interval is too big, first three rows are trimmed by group.
     """
-
     df = (
         pl.DataFrame(
             {
                 "geography": ["USA"] * 4 + ["PA"] * 4,
-                "date": [
+                "time_end": [
                     dt.date(2019, 12, 31),
                     dt.date(2020, 1, 7),
                     dt.date(2020, 1, 14),
@@ -209,11 +223,14 @@ def test_trim_outlier_intervals_handles_above_threshold():
     )
 
     output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
-        df, group_cols=("geography",)
+        df,
+        group_cols=[
+            "geography",
+        ],
     )
 
     # should drop the first 3 rows, leaving only Jan 21
-    expected = output.filter(pl.col("date") == dt.date(2020, 1, 21))
+    expected = output.filter(pl.col("time_end") == dt.date(2020, 1, 21))
 
     polars.testing.assert_frame_equal(output, expected, check_row_order=False)
 
@@ -225,7 +242,11 @@ def test_trim_outlier_intervals_handles_below_threshold(frame):
     frame = iup.IncidentUptakeData(frame)
 
     output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
-        frame, group_cols=("geography",), threshold=2
+        frame,
+        group_cols=[
+            "geography",
+        ],
+        threshold=2,
     )
 
     assert output.shape[0] == 4
@@ -235,11 +256,14 @@ def test_trim_outlier_intervals_handles_zero_std(frame):
     """
     If std dev of intervals is 0, first two rows are trimmed by group
     """
-    frame = frame.filter(pl.col("date") > dt.date(2020, 1, 1))
+    frame = frame.filter(pl.col("time_end") > dt.date(2020, 1, 1))
     frame = iup.IncidentUptakeData(frame)
 
     output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
-        frame, group_cols=("geography",)
+        frame,
+        group_cols=[
+            "geography",
+        ],
     )
 
     assert output.shape[0] == 2
@@ -251,7 +275,10 @@ def test_augment_implicit_columns(frame):
     """
     frame = iup.IncidentUptakeData(frame)
     frame = iup.models.LinearIncidentUptakeModel.augment_implicit_columns(
-        frame, group_cols=("geography",)
+        frame,
+        group_cols=[
+            "geography",
+        ],
     )
 
     assert frame.shape[0] == 8
@@ -263,19 +290,19 @@ def test_date_to_season(frame):
     Return the overwinter season, for both fall and spring dates
     """
     output = frame.with_columns(
-        date=iup.models.LinearIncidentUptakeModel.date_to_season(pl.col("date"))
+        season=iup.UptakeData.date_to_season(pl.col("time_end"))
     )
 
-    assert all(output["date"] == pl.Series(["2019/2020"] * 8))
+    assert all(output["season"] == pl.Series(["2019/2020"] * 8))
 
 
 def test_date_to_interval(frame):
     """
     Return the interval between dates by grouping factor
     """
-    output = frame.sort(["geography", "date"]).with_columns(
+    output = frame.sort(["geography", "time_end"]).with_columns(
         interval=iup.models.LinearIncidentUptakeModel.date_to_interval(
-            pl.col("date")
+            pl.col("time_end")
         ).over("geography")
     )
 
@@ -288,9 +315,9 @@ def test_date_to_elapsed(frame):
     """
     Return the time elapsed since the first date by grouping factor.
     """
-    output = frame.sort(["date", "geography"]).with_columns(
+    output = frame.sort(["time_end", "geography"]).with_columns(
         elapsed=iup.models.LinearIncidentUptakeModel.date_to_elapsed(
-            pl.col("date")
+            pl.col("time_end")
         ).over("geography")
     )
 

--- a/tests/test_linear_incident_uptake_model.py
+++ b/tests/test_linear_incident_uptake_model.py
@@ -94,9 +94,7 @@ def test_fit(frame):
     data = iup.IncidentUptakeData(frame)
     model = iup.models.LinearIncidentUptakeModel().fit(
         data,
-        [
-            "geography",
-        ],
+        ["geography"],
     )
 
     assert model.model.score(model.x, model.y) == 1.0
@@ -143,9 +141,7 @@ def test_build_scaffold_handles_groups():
     start_date = dt.date(2020, 2, 1)
     end_date = dt.date(2020, 2, 29)
     interval = "7d"
-    group_cols = [
-        "geography",
-    ]
+    group_cols = ["geography"]
 
     output = iup.models.LinearIncidentUptakeModel.build_scaffold(
         start, start_date, end_date, interval, group_cols
@@ -190,9 +186,7 @@ def test_trim_outlier_intervals_handles_two_rows(frame):
 
     output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
         frame,
-        group_cols=[
-            "geography",
-        ],
+        group_cols=["geography"],
     )
 
     assert output.shape[0] == 0
@@ -224,9 +218,7 @@ def test_trim_outlier_intervals_handles_above_threshold():
 
     output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
         df,
-        group_cols=[
-            "geography",
-        ],
+        group_cols=["geography"],
     )
 
     # should drop the first 3 rows, leaving only Jan 21
@@ -243,9 +235,7 @@ def test_trim_outlier_intervals_handles_below_threshold(frame):
 
     output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
         frame,
-        group_cols=[
-            "geography",
-        ],
+        group_cols=["geography"],
         threshold=2,
     )
 
@@ -261,9 +251,7 @@ def test_trim_outlier_intervals_handles_zero_std(frame):
 
     output = iup.models.LinearIncidentUptakeModel.trim_outlier_intervals(
         frame,
-        group_cols=[
-            "geography",
-        ],
+        group_cols=["geography"],
     )
 
     assert output.shape[0] == 2
@@ -276,9 +264,7 @@ def test_augment_implicit_columns(frame):
     frame = iup.IncidentUptakeData(frame)
     frame = iup.models.LinearIncidentUptakeModel.augment_implicit_columns(
         frame,
-        group_cols=[
-            "geography",
-        ],
+        group_cols=["geography"],
     )
 
     assert frame.shape[0] == 8

--- a/tests/test_uptake_data.py
+++ b/tests/test_uptake_data.py
@@ -14,7 +14,7 @@ def frame() -> iup.UptakeData:
     frame = pl.DataFrame(
         {
             "geography": ["USA", "PA", "USA", "PA", "USA", "PA", "USA", "PA"],
-            "date": [
+            "time_end": [
                 "2019-12-30",
                 "2019-12-30",
                 "2020-01-07",
@@ -28,7 +28,7 @@ def frame() -> iup.UptakeData:
         }
     )
 
-    frame = frame.with_columns(date=pl.col("date").str.to_date("%Y-%m-%d"))
+    frame = frame.with_columns(time_end=pl.col("time_end").str.to_date("%Y-%m-%d"))
 
     return iup.UptakeData(frame)
 
@@ -37,7 +37,7 @@ def test_split_train_test_handles_train(frame):
     """
     Return the training half of a data set.
     """
-    frame2 = frame.with_columns(date=pl.col("date") + pl.duration(days=365))
+    frame2 = frame.with_columns(time_end=pl.col("time_end") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
     output = iup.UptakeData.split_train_test([frame, frame2], start_date, "train")
@@ -49,7 +49,7 @@ def test_split_train_test_handles_test(frame):
     """
     Return the testing half of a data set.
     """
-    frame2 = frame.with_columns(date=pl.col("date") + pl.duration(days=365))
+    frame2 = frame.with_columns(time_end=pl.col("time_end") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
     output = iup.UptakeData.split_train_test([frame, frame2], start_date, "test")
@@ -63,7 +63,11 @@ def test_to_cumulative_handles_no_last(frame):
     """
     frame = iup.IncidentUptakeData(frame)
 
-    output = frame.to_cumulative(group_cols=("geography",))
+    output = frame.to_cumulative(
+        group_cols=[
+            "geography",
+        ]
+    )
 
     assert all(
         output["estimate"]
@@ -93,7 +97,10 @@ def test_to_cumulative_handles_last(frame):
     )
 
     output = frame.to_cumulative(
-        group_cols=("geography",), last_cumulative=last_cumulative
+        group_cols=[
+            "geography",
+        ],
+        last_cumulative=last_cumulative,
     )
 
     assert all(
@@ -142,7 +149,11 @@ def test_to_incident_handles_groups(frame):
     """
     frame = iup.CumulativeUptakeData(frame.filter(pl.col("estimate") <= 1.0))
 
-    output = frame.to_incident(group_cols=("geography",))
+    output = frame.to_incident(
+        group_cols=[
+            "geography",
+        ]
+    )
 
     assert all(
         output["estimate"].round(10) == pl.Series([0.0, 0.0, 1.0, 0.1, 0.2, 0.1])


### PR DESCRIPTION
After merging #75, some incompatibilities surfaced:

- NIS API data have different column names than our data objects expect (e.g. "time_end" vs. "date"). Also, NIS API data have many columns that are not grouping factors (e.g. "vaccine", "indicator", "indicator_type"). To solve this, after calling on NIS API, `main.py` now drops and renames columns to achieve the minimalist schema expected by our data objects like CumulativeUptakeData. This extra behavior is controlled from the config file.
- NIS API data may encompass multiple seasons (whereas the vax uptake code had tacitly assumed exactly one season per data set). Relatedly, NIS API data does not include the rollout dates for each season. To solve this, `insert_rollout` can now recognize multiple rollout dates per data set. This behavior is also controlled from the config file. In a change of heart, I have moved `insert_rollout` to be a method of CumulativeUptakeData, because inserting 0.0 cumulative uptake on the rollout date is not necessary for any model, but it could be useful for multiple models. This addresses issue #77. 
- NIS API data have standardized column names, so there is no need to rename the grouping factor columns if not desired. As a result, `extract_group_names` can accept a list of lists of grouping factor columns (one list per data set), rather than a list of dictionaries. To solve this, `extract_group_names` has been refactored accordingly. This addresses issue #78. 
- The pytests in `test_data_cleaning.py` are updated to reflect these changes.

Note: the updated config_template.yaml reflects my usage of 2023-24 covid booster uptake data, ksfb-ug5d, as the input for `main.py`