### PR TITLE
Update ruff pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   #####
   # Python
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.2
+    rev: v0.9.1
     hooks:
       - id: ruff
         args: ["check", "--select", "I", "--fix"]


### PR DESCRIPTION
This mismatch might be causing some problems about line breaks that differ between GitHub and local VSCode