### PR TITLE
Several pipeline improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NIS_CACHE = .cache/nisapi/clean
+NIS_CACHE = .cache/nisapi
 TOKEN_PATH = scripts/socrata_app_token.txt
 TOKEN = $(shell cat $(TOKEN_PATH))
 CONFIG = scripts/config.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NIS_CACHE = .cache/nisapi
+NIS_CACHE = .cache/nisapi/clean
 TOKEN_PATH = scripts/socrata_app_token.txt
 TOKEN = $(shell cat $(TOKEN_PATH))
 CONFIG = scripts/config.yaml

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -110,9 +110,7 @@ class UptakeData(Data):
 
 
 class IncidentUptakeData(UptakeData):
-    def to_cumulative(
-        self, group_cols: List[str,] | None, last_cumulative=None
-    ) -> pl.DataFrame:
+    def to_cumulative(self, group_cols: List[str,] | None, last_cumulative=None):
         """
         Convert incident to cumulative uptake data.
 
@@ -145,7 +143,7 @@ class IncidentUptakeData(UptakeData):
                 estimate=pl.col("estimate") + pl.col("last_cumulative")
             ).drop("last_cumulative")
 
-        return out
+        return CumulativeUptakeData(out)
 
 
 class CumulativeUptakeData(UptakeData):
@@ -178,9 +176,7 @@ class CumulativeUptakeData(UptakeData):
 
         return IncidentUptakeData(out)
 
-    def insert_rollouts(
-        self, rollouts: List[dt.date], group_cols: List[str] | None
-    ) -> pl.DataFrame:
+    def insert_rollouts(self, rollouts: List[dt.date], group_cols: List[str] | None):
         """
         Insert into cumulative uptake data rows with 0 uptake on rollout dates.
 
@@ -228,7 +224,7 @@ class CumulativeUptakeData(UptakeData):
             == 0.0
         ).all()
 
-        return frame
+        return CumulativeUptakeData(frame)
 
 
 class QuantileForecast(Data):

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -45,7 +45,9 @@ class UptakeData(Data):
         self.assert_in_schema({"time_end": pl.Date, "estimate": pl.Float64})
 
     @classmethod
-    def split_train_test(cls, uptake_data, start_date: dt.date, side: str):
+    def split_train_test(
+        cls, uptake_data: "UptakeData", start_date: dt.date, side: str
+    ) -> "UptakeData":
         """
         Concatenate Uptake data objects and split into training and test data.
 
@@ -110,7 +112,9 @@ class UptakeData(Data):
 
 
 class IncidentUptakeData(UptakeData):
-    def to_cumulative(self, group_cols: List[str,] | None, last_cumulative=None):
+    def to_cumulative(
+        self, group_cols: List[str,] | None, last_cumulative=None
+    ) -> "CumulativeUptakeData":
         """
         Convert incident to cumulative uptake data.
 
@@ -176,7 +180,9 @@ class CumulativeUptakeData(UptakeData):
 
         return IncidentUptakeData(out)
 
-    def insert_rollouts(self, rollouts: List[dt.date], group_cols: List[str] | None):
+    def insert_rollouts(
+        self, rollouts: List[dt.date], group_cols: List[str] | None
+    ) -> "CumulativeUptakeData":
         """
         Insert into cumulative uptake data rows with 0 uptake on rollout dates.
 

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -23,7 +23,7 @@ forecast_timeframe:
 
 # Spacing between multiple forecasts, for evaluation
 evaluation_timeframe:
-  interval: 14d
+  interval: 14d # Leave this blank if you don't want evaluation
 
 models: [LinearIncidentUptakeModel]
 

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -17,7 +17,7 @@ data:
 
 # The timeframe over which to generate projections
 timeframe:
-  start: 2024-02-01
+  start: [2024-02-03]
   end: 2024-04-30
   interval: 7d
 

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -15,11 +15,15 @@ data:
   # use these columns as grouping factors
   groups: [geography]
 
-# The timeframe over which to generate projections
-timeframe:
-  start: [2024-02-03, 2024-02-10]
+# Timeframe for the longest desired forecast
+forecast_timeframe:
+  start: 2024-02-03
   end: 2024-04-30
   interval: 7d
+
+# Spacing between multiple forecasts, for evaluation
+evaluation_timeframe:
+  interval: 14d
 
 models: [LinearIncidentUptakeModel]
 

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -17,7 +17,7 @@ data:
 
 # The timeframe over which to generate projections
 timeframe:
-  start: [2024-02-03]
+  start: [2024-02-03, 2024-02-10]
   end: 2024-04-30
   interval: 7d
 

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -38,11 +38,6 @@ def eval_all_forecasts(data, pred, config):
                     )
                 ).to_incident(config["data"]["groups"])
 
-                # print("TEST")
-                # print(test)
-                # print("DATA")
-                # print(incident_pred)
-
                 assert incident_pred.shape[0] == test.shape[0], (
                     "The forecast and the test data do not have the same number of dates."
                 )

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -34,12 +34,17 @@ def eval_all_forecasts(data, pred, config):
                 test = iup.CumulativeUptakeData(
                     data.filter(
                         pl.col("time_end") >= forecast_start,
-                        pl.col("time_end") <= config["timeframe"]["end"],
+                        pl.col("time_end") <= config["forecast_timeframe"]["end"],
                     )
                 ).to_incident(config["data"]["groups"])
 
-                assert incident_pred["forecast_start"][0] == test["time_end"].min(), (
-                    "Dates do not match between the forecast and the test data"
+                # print("TEST")
+                # print(test)
+                # print("DATA")
+                # print(incident_pred)
+
+                assert incident_pred.shape[0] == test.shape[0], (
+                    "The forecast and the test data do not have the same number of dates."
                 )
 
                 score = eval.score(test, incident_pred, score_fun).with_columns(

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -38,16 +38,14 @@ def eval_all_forecasts(data, pred, config):
                     )
                 ).to_incident(config["data"]["groups"])
 
-                print(incident_pred.head)
-                print(incident_pred.shape)
-                print(test.head)
-
                 assert incident_pred["forecast_start"][0] == test["time_end"].min(), (
                     "Dates do not match between the forecast and the test data"
                 )
 
-                score = eval.score(test, incident_pred, score_fun)
-                score = score.with_columns(score_fun=score_name, model=model)
+                score = eval.score(test, incident_pred, score_fun).with_columns(
+                    score_fun=pl.lit(score_name),
+                    model=pl.lit(model),
+                )
 
                 all_scores = pl.concat([all_scores, score])
 

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -66,4 +66,5 @@ if __name__ == "__main__":
     pred = pl.scan_parquet(args.pred).collect()
     data = pl.scan_parquet(args.obs).collect()
 
-    eval_all_forecasts(data, pred, config).write_parquet(args.output)
+    if config["evaluation_timeframe"]["interval"] is not None:
+        eval_all_forecasts(data, pred, config).write_parquet(args.output)

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -6,19 +6,12 @@ import yaml
 import iup.models
 
 
-def run_all_forecasts(clean_data, config) -> pl.DataFrame:
+def run_all_forecasts(data, config) -> pl.DataFrame:
     """Run all forecasts
 
     Returns:
         pl.DataFrame: data frame of forecasts, organized by model and forecast date
     """
-
-    forecast_dates = pl.date_range(
-        config["timeframe"]["start"],
-        config["timeframe"]["end"],
-        config["timeframe"]["interval"],
-        eager=True,
-    )
 
     models = [getattr(iup.models, model_name) for model_name in config["models"]]
     assert all(issubclass(model, iup.models.UptakeModel) for model in models)
@@ -26,12 +19,10 @@ def run_all_forecasts(clean_data, config) -> pl.DataFrame:
     all_forecast = pl.DataFrame()
 
     for model in models:
-        for forecast_date in forecast_dates:
-            # Get data available as of the forecast date
-
+        for forecast_date in config["timeframe"]["start"]:
             forecast = run_forecast(
                 model,
-                clean_data,
+                data,
                 grouping_factors=config["data"]["groups"],
                 forecast_start=forecast_date,
                 forecast_end=config["timeframe"]["end"],
@@ -50,20 +41,19 @@ def run_all_forecasts(clean_data, config) -> pl.DataFrame:
 
 def run_forecast(
     model,
-    observed_data,
+    data,
     grouping_factors,
     forecast_start,
     forecast_end,
 ) -> pl.DataFrame:
     """Run a single model for a single forecast date"""
 
-    # preprocess.py returns cumulative data, need to convert to incidence for LinearIncidentUptakeModel #
-    incident_data = iup.CumulativeUptakeData(observed_data).to_incident(
-        grouping_factors
-    )
+    # preprocess.py returns cumulative data, so convert to incident for LinearIncidentUptakeModel
+    incident_data = data.to_incident(grouping_factors)
 
-    incident_train_data = iup.IncidentUptakeData(
-        iup.IncidentUptakeData.split_train_test(incident_data, forecast_start, "train")
+    # Prune to only the training portion
+    incident_train_data = iup.IncidentUptakeData.split_train_test(
+        incident_data, forecast_start, "train"
     )
 
     # Fit models using the training data and make projections
@@ -91,5 +81,4 @@ if __name__ == "__main__":
 
     input_data = iup.CumulativeUptakeData(pl.scan_parquet(args.input).collect())
 
-    all_forecast = run_all_forecasts(config=config, clean_data=input_data)
-    all_forecast.write_parquet(args.output)
+    run_all_forecasts(input_data, config).write_parquet(args.output)

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -89,9 +89,7 @@ if __name__ == "__main__":
     with open(args.config, "r") as f:
         config = yaml.safe_load(f)
 
-    input_data = pl.scan_parquet(args.input).collect()
-
-    input_data = iup.CumulativeUptakeData(input_data)
+    input_data = iup.CumulativeUptakeData(pl.scan_parquet(args.input).collect())
 
     all_forecast = run_all_forecasts(config=config, clean_data=input_data)
     all_forecast.write_parquet(args.output)

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -32,7 +32,7 @@ def run_all_forecasts(clean_data, config) -> pl.DataFrame:
             forecast = run_forecast(
                 model,
                 clean_data,
-                grouping_factors=config["groups"],
+                grouping_factors=config["data"]["groups"],
                 forecast_start=forecast_date,
                 forecast_end=config["timeframe"]["end"],
             )

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -23,11 +23,7 @@ def preprocess(
     assert set(data.columns).issuperset(groups)
 
     # Insert rollout dates into the data
-    # note the awkward wrapping with the class, because insert_rollouts returns
-    # a normal data frame
-    return iup.CumulativeUptakeData(
-        iup.CumulativeUptakeData(data).insert_rollouts(rollouts, groups)
-    )
+    return iup.CumulativeUptakeData(data).insert_rollouts(rollouts, groups)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I ran the three scripts in the pipeline (preprocess.py, forecast.py, and eval.py) and found several things I wanted to improve:
- Several of the UptakeData methods are edited, along with their type-hinting, to return the correct UptakeData subclass, rather than generic polars data frames. This cleans up some of the excess type enforcing from the scripts.
- I clarified the way forecast dates are dealt with. Previously, every week between `["timeframe"]["start"]` and `["timeframe"]["end"]` in the config was used as a forecast date, resulting in multiple forecast trajectories of progressively shorter forecast horizons. Now, only the dates explicitly specified in `["timeframe"]["start"]` are used as forecast dates. If only one `["timeframe"]["start"]` is specified, then only one trajectory (per model) is forecast. If you want multiple forecast trajectories as the forecast date (i.e. `["timeframe"]["start"]`) gets pushed later into the season, shortening the forecast horizon, you must supply multiple `["timeframe"]["start"`] dates as a list in the config. The config_template.yaml is updated to show an example. This is useful, because now the forecast.py script can be used to either 1) explore model performance as the forecast date and horizon changes, or 2) make a single forecast trajectory from the last observed date into the future.
- Minor bug fixes and edits for conciseness.