### PR TITLE
Adjusted priors for linear incident uptake model

### DIFF
--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -27,21 +27,21 @@ evaluation_timeframe:
 
 # Details of the models to fit
 models:
-  - name: LinearIncidentUptakeModel,
-    seed: 0,
+  - name: LinearIncidentUptakeModel
+    seed: 0
     params:
-      a_mn: 0.0,
-      a_sd: 1.0,
-      bP_mn: 0.0,
-      bP_sd: 1.0,
-      bE_mn: 0.0,
-      bE_sd: 1.0,
-      bPE_mn: 0.0,
-      bPE_sd: 1.0,
-      sig_mn: 1.0,
+      a_mn: 0.0
+      a_sd: 0.1
+      bP_mn: 0.0
+      bP_sd: 0.1
+      bE_mn: 0.0
+      bE_sd: 0.1
+      bPE_mn: 0.0
+      bPE_sd: 0.1
+      sig_mn: 0.1
     mcmc:
-      num_warmup: 1000,
-      num_samples: 100,
+      num_warmup: 1000
+      num_samples: 100
       num_chains: 4
 
 # score metrics


### PR DESCRIPTION
Shrinking the standard deviations in the prior distributions helps prevent some of the unstable trajectories. This is a short-term fix so that we can keep developing the codebase, without such nonsensical trajectories interfering with evaluating/plotting. I also fixed some mistakes with commas in the config template.