### PR TITLE
Clean up pipeline bugs

### DIFF
--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -113,13 +113,13 @@ class UptakeData(Data):
 
 class IncidentUptakeData(UptakeData):
     def to_cumulative(
-        self, group_cols: List[str,] | None, last_cumulative=None
+        self, group_cols: List[str,], last_cumulative=None
     ) -> "CumulativeUptakeData":
         """
         Convert incident to cumulative uptake data.
 
         Parameters
-        group_cols: (str,) | None
+        group_cols: (str,)
             name(s) of the columns of grouping factors
         last_cumulative: pl.DataFrame
             additional cumulative uptake absent from the incident data, for each group
@@ -136,7 +136,7 @@ class IncidentUptakeData(UptakeData):
         out = self.with_columns(estimate=pl.col("estimate").cum_sum().over(group_cols))
 
         if last_cumulative is not None:
-            if group_cols is not None:
+            if len(group_cols) > 0:
                 out = out.join(last_cumulative, on=group_cols)
             else:
                 out = out.with_columns(
@@ -159,12 +159,12 @@ class CumulativeUptakeData(UptakeData):
             "cumulative uptake `estimate` must be a proportion"
         )
 
-    def to_incident(self, group_cols: List[str,] | None) -> IncidentUptakeData:
+    def to_incident(self, group_cols: List[str,]) -> IncidentUptakeData:
         """
         Convert cumulative to incident uptake data.
 
         Parameters
-        group_cols: (str,) | None
+        group_cols: (str,)
             name(s) of the columns of grouping factors
 
         Returns
@@ -181,7 +181,7 @@ class CumulativeUptakeData(UptakeData):
         return IncidentUptakeData(out)
 
     def insert_rollouts(
-        self, rollouts: List[dt.date], group_cols: List[str] | None
+        self, rollouts: List[dt.date], group_cols: List[str]
     ) -> "CumulativeUptakeData":
         """
         Insert into cumulative uptake data rows with 0 uptake on rollout dates.
@@ -189,7 +189,7 @@ class CumulativeUptakeData(UptakeData):
         Parameters
         rollout: List[dt.date]
             list of rollout dates
-        group_cols: tuple[str] | None
+        group_cols: tuple[str]
             names of grouping factor columns
 
         Returns
@@ -200,7 +200,7 @@ class CumulativeUptakeData(UptakeData):
         """
         frame = self
 
-        if group_cols is not None:
+        if len(group_cols) > 0:
             rollout_rows = (
                 frame.select(group_cols)
                 .unique()

--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -219,7 +219,11 @@ class CumulativeUptakeData(UptakeData):
         assert (
             (
                 frame.with_columns(
-                    season=pl.col("time_end").pipe(UptakeData.date_to_season)
+                    season=pl.col("time_end").pipe(
+                        UptakeData.date_to_season,
+                        season_start_month=min([d.month for d in rollouts]),
+                        season_start_day=min([d.day for d in rollouts]),
+                    )
                 )
                 .with_columns(
                     min=(pl.col("estimate") - pl.min("estimate")).over(group_cols)

--- a/iup/models.py
+++ b/iup/models.py
@@ -346,10 +346,7 @@ class LinearIncidentUptakeModel(UptakeModel):
         # use exactly the dates that are in the test data
         if test_data is not None:
             scaffold = (
-                test_data.filter(
-                    (pl.col("time_end") >= start_date)
-                    & (pl.col("time_end") <= end_date)
-                )
+                test_data.filter((pl.col("time_end").is_between(start_date, end_date)))
                 .select("time_end")
                 .with_columns(estimate=pl.lit(0.0))
             )

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,1 +1,2 @@
 config.yaml
+config_flu.yaml

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -1,6 +1,8 @@
 # The data sets to load and how to interpret them
 data:
-  rollouts: [2023-09-01, 2024-09-01]
+  rollouts: [2022-09-01, 2023-09-01, 2024-09-01]
+  season_start_month: 9
+  season_start_day: 1
   # filter data; eg `vaccine: covid` means filter column "vaccine" for value "covid"
   filters:
     vaccine: [covid]
@@ -11,9 +13,9 @@ data:
     indicator: [received a vaccination, Received updated bivalent booster dose (among adults who completed primary series)]
     time_type: [week]
   # keep only these data columns
-  keep: [geography, estimate, time_end]
-  # use these columns as grouping factors. Use an empty list if there are none.
-  groups: [geography]
+  keep: [estimate, time_end]
+  # use these columns as grouping factors. Almost always use at least "season", but use None if there are truly none.
+  groups: [season]
 
 # Timeframe for the longest desired forecast
 forecast_timeframe:

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -3,13 +3,13 @@ data:
   rollouts: [2023-09-01, 2024-09-01]
   # filter data; eg `vaccine: covid` means filter column "vaccine" for value "covid"
   filters:
-    vaccine: covid
-    geography_type: nation
-    domain_type: age
-    domain: 18+ years
-    indicator_type: 4-level vaccination and intent
-    indicator: received a vaccination
-    time_type: week
+    vaccine: [covid]
+    geography_type: [nation]
+    domain_type: [overall, age]
+    domain: [overall, 18+ years]
+    indicator_type: [4-level vaccination and intent, Bivalent Booster Uptake and Intention]
+    indicator: [received a vaccination, Received updated bivalent booster dose (among adults who completed primary series)]
+    time_type: [week]
   # keep only these data columns
   keep: [geography, estimate, time_end]
   # use these columns as grouping factors

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -12,7 +12,7 @@ data:
     time_type: [week]
   # keep only these data columns
   keep: [geography, estimate, time_end]
-  # use these columns as grouping factors
+  # use these columns as grouping factors. Use an empty list if there are none.
   groups: [geography]
 
 # Timeframe for the longest desired forecast

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -27,7 +27,7 @@ def eval_all_forecasts(data, pred, config):
                             pl.col("forecast_start") == forecast_start,
                         )
                     )
-                    .to_incident(config["data"]["groups"] + ["season"])
+                    .to_incident(config["data"]["groups"])
                     .with_columns(quantile=0.5)
                 )
 
@@ -36,7 +36,7 @@ def eval_all_forecasts(data, pred, config):
                         pl.col("time_end") >= forecast_start,
                         pl.col("time_end") <= config["forecast_timeframe"]["end"],
                     )
-                ).to_incident(config["data"]["groups"] + ["season"])
+                ).to_incident(config["data"]["groups"])
 
                 assert incident_pred.shape[0] == test.shape[0], (
                     "The forecast and the test data do not have the same number of dates."

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -35,8 +35,6 @@ def eval_all_forecasts(data, pred, config):
                     data.filter(
                         pl.col("time_end") >= forecast_start,
                         pl.col("time_end") <= config["forecast_timeframe"]["end"],
-                    ).with_columns(
-                        season=pl.col("time_end").pipe(iup.UptakeData.date_to_season)
                     )
                 ).to_incident(config["data"]["groups"] + ["season"])
 

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -27,7 +27,7 @@ def eval_all_forecasts(data, pred, config):
                             pl.col("forecast_start") == forecast_start,
                         )
                     )
-                    .to_incident(config["data"]["groups"])
+                    .to_incident(config["data"]["groups"] + ["season"])
                     .with_columns(quantile=0.5)
                 )
 
@@ -35,8 +35,10 @@ def eval_all_forecasts(data, pred, config):
                     data.filter(
                         pl.col("time_end") >= forecast_start,
                         pl.col("time_end") <= config["forecast_timeframe"]["end"],
+                    ).with_columns(
+                        season=pl.col("time_end").pipe(iup.UptakeData.date_to_season)
                     )
-                ).to_incident(config["data"]["groups"])
+                ).to_incident(config["data"]["groups"] + ["season"])
 
                 assert incident_pred.shape[0] == test.shape[0], (
                     "The forecast and the test data do not have the same number of dates."

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -85,10 +85,18 @@ def run_forecast(
         model["mcmc"],
     )
 
+    # Get test data, if there is any, to know exact dates for projection
+    incident_test_data = iup.IncidentUptakeData.split_train_test(
+        incident_data, forecast_start, "test"
+    )
+    if incident_test_data.height == 0:
+        incident_test_data = None
+
     cumulative_projections = fit_model.predict(
         forecast_start,
         forecast_end,
         config["forecast_timeframe"]["interval"],
+        incident_test_data,
         grouping_factors,
     )
 

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -31,7 +31,7 @@ def run_all_forecasts(data, config) -> pl.DataFrame:
             forecast = run_forecast(
                 model,
                 data,
-                grouping_factors=config["data"]["groups"] + ["season"],
+                grouping_factors=config["data"]["groups"],
                 forecast_start=forecast_date,
                 forecast_end=config["forecast_timeframe"]["end"],
             )

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -57,8 +57,13 @@ def run_forecast(
     """Run a single model for a single forecast date"""
     # preprocess.py returns cumulative data, so convert to incident for LinearIncidentUptakeModel
     cumulative_data = data.with_columns(
-        season=pl.col("time_end").pipe(iup.UptakeData.date_to_season)
+        season=pl.col("time_end").pipe(
+            iup.UptakeData.date_to_season,
+            season_start_month=min([d.month for d in config["data"]["rollouts"]]),
+            season_start_day=min([d.day for d in config["data"]["rollouts"]]),
+        )
     )
+
     incident_data = iup.CumulativeUptakeData(cumulative_data).to_incident(
         grouping_factors
     )

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -59,8 +59,8 @@ def run_forecast(
     cumulative_data = data.with_columns(
         season=pl.col("time_end").pipe(
             iup.UptakeData.date_to_season,
-            season_start_month=min([d.month for d in config["data"]["rollouts"]]),
-            season_start_day=min([d.day for d in config["data"]["rollouts"]]),
+            season_start_month=config["data"]["season_start_month"],
+            season_start_day=config["data"]["season_start_day"],
         )
     )
 

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -3,8 +3,6 @@ import argparse
 import altair as alt
 import polars as pl
 
-import iup
-
 
 def plot_projections(obs: pl.DataFrame, pred: pl.DataFrame):
     """
@@ -35,10 +33,7 @@ def plot_projections(obs: pl.DataFrame, pred: pl.DataFrame):
     # column "type" will be either "obs" or "pred"
     plot_obs = (
         obs.join(models_forecasts, how="cross")
-        .with_columns(
-            type=pl.lit("obs"),
-            season=pl.col("time_end").pipe(iup.UptakeData.date_to_season),
-        )
+        .with_columns(type=pl.lit("obs"))
         .select(["type", "model", "forecast_start", "time_end", "estimate", "season"])
         .filter(pl.col("season").is_in(pred["season"].unique()))
     )

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -28,9 +28,6 @@ def plot_projections(obs: pl.DataFrame, pred: pl.DataFrame):
     if "time_end" not in obs.columns or "estimate" not in obs.columns:
         ValueError("'time_end' or 'estimate' is missing from obs.")
 
-    assert obs["geography"].unique().to_list() == ["nation"], "Geography is not unique"
-    assert pred["geography"].unique().to_list() == ["nation"], "Geography is not unique"
-
     # get every model/forecast date combo
     models_forecasts = pred.select(["model", "forecast_start"]).unique()
 

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -1,8 +1,9 @@
 import argparse
-import datetime
 
 import altair as alt
 import polars as pl
+
+import iup
 
 
 def plot_projections(obs: pl.DataFrame, pred: pl.DataFrame):
@@ -37,17 +38,19 @@ def plot_projections(obs: pl.DataFrame, pred: pl.DataFrame):
     # column "type" will be either "obs" or "pred"
     plot_obs = (
         obs.join(models_forecasts, how="cross")
-        .with_columns(pl.lit("obs").alias("type"))
-        .select(["type", "model", "forecast_start", "time_end", "estimate"])
+        .with_columns(
+            type=pl.lit("obs"),
+            season=pl.col("time_end").pipe(iup.UptakeData.date_to_season),
+        )
+        .select(["type", "model", "forecast_start", "time_end", "estimate", "season"])
+        .filter(pl.col("season").is_in(pred["season"].unique()))
     )
 
     plot_pred = pred.with_columns(pl.lit("pred").alias("type")).select(
-        ["type", "model", "forecast_start", "time_end", "estimate"]
+        ["type", "model", "forecast_start", "time_end", "estimate", "season"]
     )
 
-    plot_data = pl.concat([plot_obs, plot_pred]).with_columns(
-        (pl.col("time_end") < datetime.date(2024, 9, 1)).alias("season_kludge")
-    )
+    plot_data = pl.concat([plot_obs, plot_pred])
 
     return (
         alt.Chart(plot_data)
@@ -58,7 +61,7 @@ def plot_projections(obs: pl.DataFrame, pred: pl.DataFrame):
             alt.Column("model"),
             alt.Row("forecast_start:T"),
             alt.Color("type"),
-            alt.Detail("season_kludge"),
+            alt.Detail("season"),
         )
     )
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -18,9 +18,6 @@ def preprocess(
     season_start_month: int,
     season_start_day: int,
 ) -> iup.CumulativeUptakeData:
-    if groups is None:
-        groups = []
-
     # Filter to correct rows and columns
     data = iup.CumulativeUptakeData(
         raw_data.filter([pl.col(k).is_in(v) for k, v in filters.items()])
@@ -42,7 +39,8 @@ def preprocess(
     )
 
     # Ensure that the desired grouping factors are found in all data sets
-    assert set(data.columns).issuperset(groups)
+    if groups is not None:
+        assert set(data.columns).issuperset(groups)
 
     return data
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -16,8 +16,12 @@ def preprocess(
     groups: List[str],
     rollouts: List[datetime.date],
 ) -> iup.CumulativeUptakeData:
-    # Prune data to correct rows and columns
-    data = raw_data.filter(**filters).select(keep).sort("time_end").collect()
+    data = (
+        raw_data.filter([pl.col(k).is_in(v) for k, v in filters.items()])
+        .select(keep)
+        .sort("time_end")
+        .collect()
+    )
 
     # Ensure that the desired grouping factors are found in all data sets
     assert set(data.columns).issuperset(groups)
@@ -49,3 +53,5 @@ if __name__ == "__main__":
     )
 
     clean_data.write_parquet(args.output)
+
+    print(clean_data)

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -53,5 +53,3 @@ if __name__ == "__main__":
     )
 
     clean_data.write_parquet(args.output)
-
-    print(clean_data)

--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -57,7 +57,7 @@ def test_insert_rollouts_handles_no_groups(frame):
         time_end=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d")
     )
     rollouts = [dt.date(2020, 1, 1), dt.date(2021, 1, 1)]
-    group_cols = None
+    group_cols = []
     frame = iup.CumulativeUptakeData(frame.drop(["indicator", "geography"]))
 
     output = frame.insert_rollouts(rollouts, group_cols)

--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -18,6 +18,7 @@ def frame():
             "time_end": ["2020-01-07", "2020-01-14", "2020-01-21"],
             "estimate": [0.0, 0.1, 0.2],
             "indicator": ["refused", "booster", "booster"],
+            "season": ["2019/2020", "2019/2020", "2019/2020"],
         }
     )
 
@@ -37,7 +38,7 @@ def test_insert_rollouts_handles_groups(frame):
     ]
     frame = iup.CumulativeUptakeData(frame.drop("indicator"))
 
-    output = frame.insert_rollouts(rollouts, group_cols)
+    output = frame.insert_rollouts(rollouts, group_cols, 9, 1)
 
     assert output.shape[0] == 7
     assert (
@@ -57,10 +58,10 @@ def test_insert_rollouts_handles_no_groups(frame):
         time_end=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d")
     )
     rollouts = [dt.date(2020, 1, 1), dt.date(2021, 1, 1)]
-    group_cols = []
+    group_cols = None
     frame = iup.CumulativeUptakeData(frame.drop(["indicator", "geography"]))
 
-    output = frame.insert_rollouts(rollouts, group_cols)
+    output = frame.insert_rollouts(rollouts, group_cols, 9, 1)
 
     assert output.shape[0] == 5
     assert (

--- a/tests/test_linear_incident_uptake_model.py
+++ b/tests/test_linear_incident_uptake_model.py
@@ -153,10 +153,22 @@ def test_build_scaffold_handles_groups():
     start_date = dt.date(2020, 2, 1)
     end_date = dt.date(2020, 2, 29)
     interval = "7d"
+    test_data = pl.DataFrame(
+        {
+            "time_end": [
+                dt.date(2020, 2, 1),
+                dt.date(2020, 2, 8),
+                dt.date(2020, 2, 15),
+                dt.date(2020, 2, 22),
+                dt.date(2020, 2, 29),
+            ],
+            "estimate": 0.0,
+        }
+    )
     group_cols = ["geography", "season"]
 
     output = iup.models.LinearIncidentUptakeModel.build_scaffold(
-        start, start_date, end_date, interval, group_cols
+        start, start_date, end_date, interval, test_data, group_cols
     )
 
     assert output.shape == (10, 8)


### PR DESCRIPTION
There are some bugs in pipeline, which I am searching out and solving. So far, I have found and fixed the following:
- Different filtering terms are required for the historical vs. recent forms of the NIS data within a vaccine type. E.g. for covid, the historical data requires `domain_type` of `overall` and `domain` of `overall`, whereas the recent data requires `domain_type` of `age` and `domain` of `18_ years`. You can now use multiple filtering terms to make sure neither the historical nor the recent data are accidentally filtered out during preprocessing.
- Many operations to prepare the data for model fitting (e.g. converting cumulative to incident) must be performed over some grouping factors. Season is now one of these grouping factors (e.g. so that the incident uptake on the first date of a new season isn't -40%).