### PR TITLE
Refactor of data/fitting/forecasting with addition of Hill model

### DIFF
--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -2,8 +2,9 @@ import datetime as dt
 from typing import List
 
 import polars as pl
-import utils
 from polars.datatypes.classes import DataTypeClass
+
+import iup.utils
 
 
 class Data(pl.DataFrame):
@@ -197,12 +198,12 @@ class IncidentUptakeData(UptakeData):
         if groups is not None:
             rank = pl.col("time_end").rank().over(groups)
             shifted_standard_interval = (
-                pl.col("interval").pipe(utils.standardize).shift(1).over(groups)
+                pl.col("interval").pipe(iup.utils.standardize).shift(1).over(groups)
             )
         else:
             rank = pl.col("time_end").rank()
             shifted_standard_interval = (
-                pl.col("interval").pipe(utils.standardize).shift(1)
+                pl.col("interval").pipe(iup.utils.standardize).shift(1)
             )
 
         return IncidentUptakeData(

--- a/iup/models.py
+++ b/iup/models.py
@@ -904,12 +904,22 @@ class HillModel(UptakeModel):
             start_date, end_date, interval, test_data, self.group_combos
         ).drop("estimate")
 
+        # Left off here! Must produce Hill Model predictions, which won't require project_sequentially
+        predictive = Predictive(self.model, self.mcmc.get_samples())
+        predictions = predictive(
+            self.rng_key,
+            elapsed=scaffold["elapsed"].to_numpy(),
+            season=scaffold["season"].to_numpy(),
+        )["obs"]
+
+        return predictions
+
+        # Use what's above with predictive, not what's below. MUST STILL ADD elapsed & season to scaffold!
+
         if group_cols is not None:
             groups = scaffold.partition_by(group_cols)
         else:
             groups = [scaffold]
-
-        # Left off here! Must produce Hill Model predictions, which won't require project_sequentially
 
         for g in range(len(groups)):
             if group_cols is not None:

--- a/iup/models.py
+++ b/iup/models.py
@@ -537,7 +537,7 @@ class LinearIncidentUptakeModel(UptakeModel):
         )
 
         scaffold = build_scaffold(
-            start_date, end_date, interval, test_data, group_cols, self.group_combos
+            start_date, end_date, interval, test_data, self.group_combos
         ).drop("estimate")
 
         scaffold = LinearIncidentUptakeModel.augment_implicit_columns(
@@ -901,7 +901,7 @@ class HillModel(UptakeModel):
             start_date = min(test_data["time_end"])
 
         scaffold = build_scaffold(
-            start_date, end_date, interval, test_data, group_cols, self.group_combos
+            start_date, end_date, interval, test_data, self.group_combos
         ).drop("estimate")
 
         if group_cols is not None:
@@ -981,7 +981,6 @@ def build_scaffold(
     end_date: dt.date,
     interval: str,
     test_data: pl.DataFrame | None,
-    group_cols: List[str,] | None,
     group_combos: pl.DataFrame | None,
 ) -> pl.DataFrame:
     """
@@ -997,8 +996,6 @@ def build_scaffold(
         following timedelta convention (e.g. '7d' = seven days)
     test_data: pl.DataFrame | None
         test data, if evaluation is being done, to provide exact dates
-    group_cols: (str,) | None
-        name(s) of the columns for the grouping factors
     group_combos: pl.DataFrame | None
         all unique combinations of grouping factors in the data
 

--- a/iup/models.py
+++ b/iup/models.py
@@ -712,8 +712,8 @@ class HillModel(UptakeModel):
         n_high=5.0,
         A_low=0.0,
         A_high=1.0,
-        H_low=0.0,
-        H_high=1.0,
+        H_low=10.0,
+        H_high=180.0,
         sig_mn=1.0,
     ):
         """
@@ -802,6 +802,11 @@ class HillModel(UptakeModel):
             num_samples=mcmc["num_samples"],
             num_chains=mcmc["num_chains"],
         )
+
+        print(data["estimate"].to_numpy())
+        print(data["elapsed"].to_numpy())
+        print(season)
+
         self.mcmc.run(
             self.rng_key,
             cum_uptake=data["estimate"].to_numpy(),

--- a/iup/models.py
+++ b/iup/models.py
@@ -171,7 +171,7 @@ class LinearIncidentUptakeModel(UptakeModel):
 
         incident_data = LinearIncidentUptakeModel.augment_columns(incident_data, groups)
 
-        incident_data = incident_data.trim_outlier_intervals(groups)
+        # incident_data = incident_data.trim_outlier_intervals(groups)
 
         return incident_data
 
@@ -258,7 +258,7 @@ class LinearIncidentUptakeModel(UptakeModel):
         self.start = self.extract_starting_conditions(data, groups)
 
         data = IncidentUptakeData(
-            data.with_columns(
+            data.trim_outlier_intervals(groups).with_columns(
                 previous_std=pl.col("previous").pipe(iup.utils.standardize),
                 elapsed_std=pl.col("elapsed").pipe(iup.utils.standardize),
                 daily_std=pl.col("daily").pipe(iup.utils.standardize),
@@ -463,11 +463,11 @@ class LinearIncidentUptakeModel(UptakeModel):
 
         scaffold = build_scaffold(
             start_date, end_date, interval, test_data, self.group_combos
-        ).drop("estimate")
+        )
 
         scaffold = LinearIncidentUptakeModel.augment_columns(
-            IncidentUptakeData(scaffold, groups), groups
-        )
+            IncidentUptakeData(scaffold), groups
+        ).drop("estimate")
 
         if groups is not None:
             scaffold = scaffold.join(

--- a/iup/utils.py
+++ b/iup/utils.py
@@ -1,0 +1,55 @@
+import polars as pl
+
+
+def standardize(x, mn=None, sd=None):
+    """
+    Standardize: subtract mean and divide by standard deviation.
+
+    Parameters
+    x: pl.Expr | float64
+        the numbers to standardize
+    mn: float64
+        the term to subtract, if not the mean of x
+    sd: float64
+        the term to divide by, if not the standard deviation of x
+
+    Returns
+    pl.Expr | float
+        the standardized numbers
+
+    Details
+    If the standard deviation is 0, all standardized values are 0.0.
+    """
+    if type(x) is pl.Expr:
+        if mn is not None:
+            return (x - mn) / sd
+        else:
+            return (
+                pl.when(x.drop_nulls().n_unique() == 1)
+                .then(0.0)
+                .otherwise((x - x.mean()) / x.std())
+            )
+    else:
+        if mn is not None:
+            return (x - mn) / sd
+        else:
+            return (x - x.mean()) / x.std()
+
+
+def unstandardize(x, mn, sd):
+    """
+    Unstandardize: add standard deviation and multiply by mean.
+
+    Parameters
+    x: pl.Expr
+        the numbers to unstandardize
+    mn: float64
+        the term to add
+    sd: float64
+        the term to multiply by
+
+    Returns
+    pl.Expr
+        the unstandardized numbers
+    """
+    return x * sd + mn

--- a/iup/utils.py
+++ b/iup/utils.py
@@ -53,3 +53,28 @@ def unstandardize(x, mn, sd):
         the unstandardized numbers
     """
     return x * sd + mn
+
+
+def extract_standards(data: pl.DataFrame, var_cols: tuple) -> dict:
+    """
+    Extract means and standard deviations from data frame columns.
+
+    Parameters
+    data: pl.DataFrame
+        data frame with some columns to be standardized
+    var_cols: (str,)
+        column names of variables to be standardized
+
+    Returns
+    dict
+        means and standard deviations for each variable column
+
+    Details
+    Keys are the variable names, and values are themselves
+    dictionaries of mean and standard deviation.
+    """
+    standards = {
+        var: {"mean": data[var].mean(), "std": data[var].std()} for var in var_cols
+    }
+
+    return standards

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -30,17 +30,31 @@ evaluation_timeframe:
 
 # Details of the models to fit
 models:
-  - name: LinearIncidentUptakeModel
+  # - name: LinearIncidentUptakeModel
+  #   seed: 0
+  #   params:
+  #     a_mn: 0.0
+  #     a_sd: 0.1
+  #     bP_mn: 0.0
+  #     bP_sd: 0.1
+  #     bE_mn: 0.0
+  #     bE_sd: 0.1
+  #     bPE_mn: 0.0
+  #     bPE_sd: 0.1
+  #     sig_mn: 0.1
+  #   mcmc:
+  #     num_warmup: 1000
+  #     num_samples: 100
+  #     num_chains: 4
+  - name: HillModel
     seed: 0
     params:
-      a_mn: 0.0
-      a_sd: 0.1
-      bP_mn: 0.0
-      bP_sd: 0.1
-      bE_mn: 0.0
-      bE_sd: 0.1
-      bPE_mn: 0.0
-      bPE_sd: 0.1
+      n_low: 1.0
+      n_high: 5.0
+      A_low: 0.0
+      A_high: 1.0
+      H_low: 10.0
+      H_high: 180.0
       sig_mn: 0.1
     mcmc:
       num_warmup: 1000

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -15,6 +15,7 @@ data:
   # keep only these data columns
   keep: [estimate, time_end]
   # use these columns as grouping factors. Almost always use at least "season", but use None if there are truly none.
+  # Right now, this can only be "season"
   groups: [season]
 
 # Timeframe for the longest desired forecast

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -86,14 +86,14 @@ def run_forecast(
     # Get test data, if there is any, to know exact dates for projection
     test_data = iup.UptakeData.split_train_test(data, forecast_start, "test")
     if test_data.height == 0:
-        incident_test_data = None
+        test_data = None
 
     # LEFT OFF HERE - MAY BE MISTAKES BELOW
     cumulative_projections = fit_model.predict(
         forecast_start,
         forecast_end,
         config["forecast_timeframe"]["interval"],
-        incident_test_data,
+        test_data,
         grouping_factors,
     )
 

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -63,11 +63,11 @@ def run_forecast(
     if model["name"] == "LinearIncidentUptakeModel":
         data = data.to_incident(grouping_factors)
         train_data = iup.UptakeData.split_train_test(data, forecast_start, "train")
-    elif model["name"] == "Hill":
+    elif model["name"] == "HillModel":
         data = iup.CumulativeUptakeData(
             data.with_columns(
                 elapsed=iup.models.HillModel.date_to_elapsed(
-                    pl.col("date"),
+                    pl.col("time_end"),
                     config["data"]["season_start_month"],
                     config["data"]["season_start_day"],
                 )

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -89,7 +89,12 @@ def run_forecast(
         config["forecast_timeframe"]["interval"],
         test_data,
         grouping_factors,
+        config["data"]["season_start_month"],
+        config["data"]["season_start_day"],
     )
+
+    if grouping_factors is None:
+        grouping_factors = ["season"]
 
     cumulative_projections = (
         cumulative_projections.group_by(grouping_factors + ["time_end"])

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -61,12 +61,10 @@ def run_forecast(
 
     # Format training data according to the type of model desired
     if model["name"] == "LinearIncidentUptakeModel":
-        train_data = data.to_incident(grouping_factors)
-        train_data = iup.UptakeData.split_train_test(
-            train_data, forecast_start, "train"
-        )
+        data = data.to_incident(grouping_factors)
+        train_data = iup.UptakeData.split_train_test(data, forecast_start, "train")
     elif model["name"] == "Hill":
-        train_data = iup.CumulativeUptakeData(
+        data = iup.CumulativeUptakeData(
             data.with_columns(
                 elapsed=iup.models.HillModel.date_to_elapsed(
                     pl.col("date"),
@@ -85,14 +83,12 @@ def run_forecast(
         model["mcmc"],
     )
 
-    # LEFT OFF HERE - MAY BE MISTAKES BELOW
     # Get test data, if there is any, to know exact dates for projection
-    incident_test_data = iup.IncidentUptakeData.split_train_test(
-        data, forecast_start, "test"
-    )
-    if incident_test_data.height == 0:
+    test_data = iup.UptakeData.split_train_test(data, forecast_start, "test")
+    if test_data.height == 0:
         incident_test_data = None
 
+    # LEFT OFF HERE - MAY BE MISTAKES BELOW
     cumulative_projections = fit_model.predict(
         forecast_start,
         forecast_end,

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -82,7 +82,6 @@ def run_forecast(
     if test_data.height == 0:
         test_data = None
 
-    # LEFT OFF HERE - MAY BE MISTAKES BELOW AND IN USED FUNCTIONS
     cumulative_projections = fit_model.predict(
         forecast_start,
         forecast_end,

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -88,7 +88,7 @@ def run_forecast(
     if test_data.height == 0:
         test_data = None
 
-    # LEFT OFF HERE - MAY BE MISTAKES BELOW
+    # LEFT OFF HERE - MAY BE MISTAKES BELOW AND IN USED FUNCTIONS
     cumulative_projections = fit_model.predict(
         forecast_start,
         forecast_end,

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -1,5 +1,4 @@
 import argparse
-import datetime
 from typing import List
 
 import nisapi
@@ -14,11 +13,9 @@ def preprocess(
     filters: dict,
     keep: List[str],
     groups: List[str] | None,
-    rollouts: List[datetime.date],
     season_start_month: int,
     season_start_day: int,
 ) -> iup.CumulativeUptakeData:
-    # Filter to correct rows and columns
     data = iup.CumulativeUptakeData(
         raw_data.filter([pl.col(k).is_in(v) for k, v in filters.items()])
         .select(keep)
@@ -33,12 +30,6 @@ def preprocess(
         )
     )
 
-    # Insert rollout dates into the data
-    data = iup.CumulativeUptakeData(
-        data.insert_rollouts(rollouts, groups, season_start_month, season_start_day)
-    )
-
-    # Ensure that the desired grouping factors are found in all data sets
     if groups is not None:
         assert set(data.columns).issuperset(groups)
 
@@ -64,7 +55,6 @@ if __name__ == "__main__":
         filters=config["data"]["filters"],
         keep=config["data"]["keep"],
         groups=config["data"]["groups"],
-        rollouts=config["data"]["rollouts"],
         season_start_month=config["data"]["season_start_month"],
         season_start_day=config["data"]["season_start_day"],
     )


### PR DESCRIPTION
While adding the Hill function as a second model option, I realized how messy much of the data preparation, model fitting, and forecasting code had become. This led me to a sweeping refactor, in which I've tried to streamline and modularize these steps. 

The following are within my intended scope for this PR:
- refactor many of the steps before evaluation (mostly completed, but more tweaks may be necessary)
- add a Hill model, with the option of "random effects" by season (mostly completed, but see below)
- refactor all the pytests affected (not yet started, but must happen before merging)

The following are outside my intended scope for this PR:
- refactoring the mechanics of the linear incident uptake model itself
- using empirical estimates of observation error
- anything having to do with evaluation metrics or plots

Because the in-scope tasks are incomplete, this is currently a draft PR not yet ready for review. However, in the meantime, I would appreciate a little bit of targeted feedback. The Hill model operates smoothly when there are no "random effects," but when season is used as a "random effect," this error emerges from many layers within numpyro:

`python IndexError: Too many indices: 0-dimensional array indexed with 1 regular index`

At first glance, I would assume this arises from improper "random effects" syntax in my definition of the Hill model, in `iup/models.py` lines 561-601. @swo, @afmagee42, @Fuhan-Yang, could you please take a look at these lines to see if any obvious violations of numpyro logic stand out?

All other aspects of review can wait. And I apologize in advance - this will be a large PR.
