### PR TITLE
Std dev of estimate as a data column

### DIFF
--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -13,7 +13,7 @@ data:
     indicator: [received a vaccination, Received updated bivalent booster dose (among adults who completed primary series)]
     time_type: [week]
   # keep only these data columns
-  keep: [estimate, time_end]
+  keep: [estimate, time_end, lci, uci]
   # use these columns as grouping factors. Almost always use at least "season", but use None if there are truly none.
   groups:
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -29,8 +29,10 @@ def preprocess(
                 season_start_month=season_start_month,
                 season_start_day=season_start_day,
             ),
-            sdev=(pl.col("uci") - pl.col("lci")) / (2 * st.norm.ppf(0.975, 0, 1)),
+            uci=pl.col("uci") - pl.col("estimate"),
+            lci=pl.col("estimate") - pl.col("lci"),
         )
+        .with_columns(sdev=pl.max_horizontal("uci", "lci") / st.norm.ppf(0.975, 0, 1))
         .drop(["lci", "uci"])
     )
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -3,6 +3,7 @@ from typing import List
 
 import nisapi
 import polars as pl
+import scipy.stats as st
 import yaml
 
 import iup
@@ -27,8 +28,10 @@ def preprocess(
                 iup.utils.date_to_season,
                 season_start_month=season_start_month,
                 season_start_day=season_start_day,
-            )
+            ),
+            sdev=(pl.col("uci") - pl.col("lci")) / (2 * st.norm.ppf(0.975, 0, 1)),
         )
+        .drop(["lci", "uci"])
     )
 
     if groups is not None:


### PR DESCRIPTION
In anticipation of refactored models that require the estimated error in observed uptake, this PR adds the standard deviation of observed uptake as a column in the preprocessed data.

I don't know how the upper and lower bounds of the "95% confidence intervals" in the NIS data are calculated. But with a truncated normal distribution in mind to describe the observation error, I have taken the width of the reported 95% confidence interval, divided by 2, and then divided by ~1.96 to estimate a standard deviation of sorts for the observed uptake.