### PR TITLE
Refactor forecast script (alternative)

### DIFF
--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -1,6 +1,6 @@
 import argparse
 import datetime as dt
-from typing import Any, List, Type
+from typing import Any
 
 import polars as pl
 import yaml
@@ -26,99 +26,80 @@ def run_all_forecasts(data, config) -> pl.DataFrame:
     else:
         forecast_dates = [config["forecast_timeframe"]["start"]]
 
-    all_forecast = pl.DataFrame()
-
-    for config_model in config["models"]:
-        model_name = config_model["name"]
-        model_class = getattr(iup.models, model_name)
-
-        assert issubclass(model_class, iup.models.UptakeModel), (
-            f"{model_name} is not a valid model type!"
-        )
-
-        augmented_data = model_class.augment_data(
-            data,
-            config["data"]["season_start_month"],
-            config["data"]["season_start_day"],
-            config["data"]["groups"],
-            config["data"]["rollouts"],
-        )
-
-        for forecast_date in forecast_dates:
-            forecast = run_forecast(
-                data=augmented_data,
-                model_class=model_class,
-                seed=config_model["seed"],
-                params=config_model["params"],
-                mcmc=config_model["mcmc"],
-                grouping_factors=config["data"]["groups"],
-                forecast_start=forecast_date,
-                forecast_end=config["forecast_timeframe"]["end"],
-                forecast_interval=config["forecast_timeframe"]["interval"],
-                season_start_month=config["data"]["season_start_month"],
-                season_start_day=config["data"]["season_start_day"],
+    return pl.concat(
+        [
+            run_forecast1(
+                config_model=config_model,
+                config=config,
+                data=data,
+                forecast_date=forecast_date,
             )
-
-            forecast = forecast.with_columns(
-                forecast_start=forecast_date,
-                forecast_end=config["forecast_timeframe"]["end"],
-                model=pl.lit(model_name),
-            )
-
-            all_forecast = pl.concat([all_forecast, forecast])
-
-    return all_forecast
+            for config_model in config["models"]
+            for forecast_date in forecast_dates
+        ]
+    )
 
 
-def run_forecast(
+def run_forecast1(
+    config_model: dict[str, Any],
+    config: dict[str, Any],
+    forecast_date: dt.date,
     data: iup.UptakeData,
-    model_class: Type[iup.models.UptakeModel],
-    seed: int,
-    params: dict[str, Any],
-    mcmc: dict[str, Any],
-    grouping_factors: List[str] | None,
-    forecast_start: dt.date,
-    forecast_end: dt.date,
-    forecast_interval: str,
-    season_start_month: int,
-    season_start_day: int,
-) -> pl.DataFrame:
-    """Run a single model for a single forecast date"""
-    train_data = iup.UptakeData.split_train_test(data, forecast_start, "train")
+):
+    model_name = config_model["name"]
+    model_class = getattr(iup.models, model_name)
+
+    assert issubclass(model_class, iup.models.UptakeModel), (
+        f"{model_name} is not a valid model type!"
+    )
+
+    augmented_data = model_class.augment_data(
+        data=data,
+        season_start_month=config["data"]["season_start_month"],
+        season_start_day=config["data"]["season_start_day"],
+        groups=config["data"]["groups"],
+        rollouts=config["data"]["rollouts"],
+    )
+
+    train_data = iup.UptakeData.split_train_test(augmented_data, forecast_date, "train")
 
     # Make an instance of the model, fit it using training data, and make projections
-    fit_model = model_class(seed).fit(
+    fit_model = model_class(config_model["seed"]).fit(
         train_data,
-        grouping_factors,
-        params,
-        mcmc,
+        config["data"]["groups"],
+        config_model["params"],
+        config_model["mcmc"],
     )
 
     # Get test data, if there is any, to know exact dates for projection
-    test_data = iup.UptakeData.split_train_test(data, forecast_start, "test")
+    test_data = iup.UptakeData.split_train_test(augmented_data, forecast_date, "test")
     if test_data.height == 0:
         test_data = None
 
     cumulative_projections = fit_model.predict(
-        start_date=forecast_start,
-        end_date=forecast_end,
-        interval=forecast_interval,
+        start_date=forecast_date,
+        end_date=config["forecast_timeframe"]["end"],
+        interval=config["forecast_timeframe"]["interval"],
         test_data=test_data,
-        groups=grouping_factors,
-        season_start_month=season_start_month,
-        season_start_day=season_start_day,
+        groups=config["data"]["groups"],
+        season_start_month=config["data"]["season_start_month"],
+        season_start_day=config["data"]["season_start_day"],
     )
 
+    grouping_factors = config["data"]["groups"]
     if grouping_factors is None:
         grouping_factors = ["season"]
 
-    cumulative_projections = (
+    return (
         cumulative_projections.group_by(grouping_factors + ["time_end"])
         .agg(pl.col("estimate").mean().alias("estimate"))
         .sort("time_end")
+        .with_columns(
+            forecast_start=forecast_date,
+            forecast_end=config["forecast_timeframe"]["end"],
+            model=pl.lit(model_name),
+        )
     )
-
-    return cumulative_projections
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is another approach to #133 

- Do the same renaming as in #133 
- Rather than looping over models, setting up augmented data, then looping over dates, and calling the one-forecast function, instead loop over models & forecast dates and call the one-forecast function.
  - Con: you augment the data multiple times
  - Pro: there are fewer interfaces, and only one layer of calls.
  - Compared to #133 , you don't end up with as desirably-dumb one-forecast function, but it means that you don't need to define another function interface

I encourage #133; this one is more of a suggestion for consideration; feel free to close if it's not interesting