### PR TITLE
Add individual projections and interval in plotting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: $(PROJ_PLOTS) $(SUMMARY_PLOTS)
 $(PROJ_PLOTS) $(SUMMARY_PLOTS): scripts/postprocess.py $(FORECASTS) $(RAW_DATA)
 	python $< \
 		--pred=$(FORECASTS) --obs=$(RAW_DATA) --proj_output=$(PROJ_PLOTS) \
-		--summary_output=$(SUMMARY_PLOTS)	
+		--summary_output=$(SUMMARY_PLOTS)
 
 # $(SCORES): scripts/eval.py $(FORECASTS) $(CONFIG)
 # 	python $< --pred=$(FORECASTS) --obs=$(RAW_DATA) --config=$(CONFIG) --output=$@

--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,29 @@ RAW_DATA = data/nis_raw.parquet
 FORECASTS = data/forecasts.parquet
 SCORES = data/scores.parquet
 PROJ_PLOTS = output/projections.png
+SUMMARY_PLOTS = output/summary.png
 SCORE_PLOTS = output/scores.png
 
 .PHONY: cache
 
-all: $(PROJ_PLOTS) $(SCORE_PLOTS)
+# all: $(PROJ_PLOTS) $(SCORE_PLOTS)
+all: $(PROJ_PLOTS) $(SUMMARY_PLOTS)
+# $(PROJ_PLOTS) $(SCORE_PLOTS): scripts/postprocess.py $(FORECASTS) $(RAW_DATA) $(SCORES)
+# 	python $< \
+# 		--pred=$(FORECASTS) --obs=$(RAW_DATA) --score=$(SCORES) \
+# 		--proj_output=$(PROJ_PLOTS) --score_output=$(SCORE_PLOTS)
 
-$(PROJ_PLOTS) $(SCORE_PLOTS): scripts/postprocess.py $(FORECASTS) $(RAW_DATA) $(SCORES)
+# $(SCORES): scripts/eval.py $(FORECASTS) $(CONFIG)
+# 	python $< --pred=$(FORECASTS) --obs=$(RAW_DATA) --config=$(CONFIG) --output=$@
+
+$(PROJ_PLOTS) $(SUMMARY_PLOTS): scripts/postprocess.py $(FORECASTS) $(RAW_DATA)
 	python $< \
-		--pred=$(FORECASTS) --obs=$(RAW_DATA) --score=$(SCORES) \
-		--proj_output=$(PROJ_PLOTS) --score_output=$(SCORE_PLOTS)
+		--pred=$(FORECASTS) --obs=$(RAW_DATA) --proj_output=$(PROJ_PLOTS) \
+		--summary_output=$(SUMMARY_PLOTS)	
 
-$(SCORES): scripts/eval.py $(FORECASTS) $(CONFIG)
-	python $< --pred=$(FORECASTS) --obs=$(RAW_DATA) --config=$(CONFIG) --output=$@
+# $(SCORES): scripts/eval.py $(FORECASTS) $(CONFIG)
+# 	python $< --pred=$(FORECASTS) --obs=$(RAW_DATA) --config=$(CONFIG) --output=$@
+
 
 $(FORECASTS): scripts/forecast.py $(RAW_DATA) $(CONFIG)
 	python $< --input=$(RAW_DATA) --config=$(CONFIG) --output=$@

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,10 @@ all: $(PROJ_PLOTS) $(SUMMARY_PLOTS)
 # 		--pred=$(FORECASTS) --obs=$(RAW_DATA) --score=$(SCORES) \
 # 		--proj_output=$(PROJ_PLOTS) --score_output=$(SCORE_PLOTS)
 
-# $(SCORES): scripts/eval.py $(FORECASTS) $(CONFIG)
-# 	python $< --pred=$(FORECASTS) --obs=$(RAW_DATA) --config=$(CONFIG) --output=$@
-
 $(PROJ_PLOTS) $(SUMMARY_PLOTS): scripts/postprocess.py $(FORECASTS) $(RAW_DATA)
 	python $< \
-		--pred=$(FORECASTS) --obs=$(RAW_DATA) --proj_output=$(PROJ_PLOTS) \
-		--summary_output=$(SUMMARY_PLOTS)
+		--pred=$(FORECASTS) --obs=$(RAW_DATA) --config=$(CONFIG) \
+		--proj_output=$(PROJ_PLOTS) --summary_output=$(SUMMARY_PLOTS)
 
 # $(SCORES): scripts/eval.py $(FORECASTS) $(CONFIG)
 # 	python $< --pred=$(FORECASTS) --obs=$(RAW_DATA) --config=$(CONFIG) --output=$@

--- a/iup/models.py
+++ b/iup/models.py
@@ -618,6 +618,7 @@ class LinearIncidentUptakeModel(UptakeModel):
                     value_name="estimate",
                 )
                 .with_columns(sample_id=pl.col("sample_id"))
+                .drop(["elapsed", "interval"])
             )
 
         cumulative_projection = pl.concat(combos)

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -23,10 +23,6 @@ forecast_timeframe:
   end: 2024-04-30
   interval: 7d
 
-# Spacing between multiple forecasts, for evaluation
-evaluation_timeframe:
-  interval: 14d # Leave this blank if you don't want evaluation
-
 # Details of the models to fit
 models:
   - name: LinearIncidentUptakeModel
@@ -64,3 +60,14 @@ models:
 
 # score metrics
 score_funs: [mspe, mean_bias, eos_abe]
+
+# Spacing between multiple forecasts, for evaluation
+evaluation_timeframe:
+  interval: 14d # Leave this blank if you don't want evaluation
+
+# Prediction credible interval
+prediction:
+  interval:
+    lower: 0.025
+    upper: 0.975
+  n_samples: 20

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -65,9 +65,9 @@ score_funs: [mspe, mean_bias, eos_abe]
 evaluation_timeframe:
   interval: 14d # Leave this blank if you don't want evaluation
 
-# Prediction credible interval
-prediction:
-  interval:
-    lower: 0.025
-    upper: 0.975
-  n_samples: 20
+# Prediction credible interval plot
+forecast_plots:
+  interval: # need to be a percentile #
+    lower: 2.5
+    upper: 97.5
+  n_trajectories: 20

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -56,19 +56,6 @@ def run_all_forecasts(data, config) -> pl.DataFrame:
                 model=pl.lit(model["name"]),
             )
 
-            # only select columns relevant to evaluation #
-            forecast = forecast.select(
-                [
-                    "time_end",
-                    "season",
-                    "sample_id",
-                    "estimate",
-                    "forecast_start",
-                    "forecast_end",
-                    "model",
-                ]
-            )
-
             all_forecast = pl.concat([all_forecast, forecast])
 
     return all_forecast
@@ -111,12 +98,6 @@ def run_forecast(
 
     if grouping_factors is None:
         grouping_factors = ["season"]
-
-    # cumulative_projections = (
-    #     cumulative_projections.group_by(grouping_factors + ["time_end"])
-    #     .agg(pl.col("estimate").mean().alias("estimate"))
-    #     .sort("time_end")
-    # )
 
     return cumulative_projections
 

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -56,6 +56,19 @@ def run_all_forecasts(data, config) -> pl.DataFrame:
                 model=pl.lit(model["name"]),
             )
 
+            # only select columns relevant to evaluation #
+            forecast = forecast.select(
+                [
+                    "time_end",
+                    "season",
+                    "sample_id",
+                    "estimate",
+                    "forecast_start",
+                    "forecast_end",
+                    "model",
+                ]
+            )
+
             all_forecast = pl.concat([all_forecast, forecast])
 
     return all_forecast
@@ -99,11 +112,11 @@ def run_forecast(
     if grouping_factors is None:
         grouping_factors = ["season"]
 
-    cumulative_projections = (
-        cumulative_projections.group_by(grouping_factors + ["time_end"])
-        .agg(pl.col("estimate").mean().alias("estimate"))
-        .sort("time_end")
-    )
+    # cumulative_projections = (
+    #     cumulative_projections.group_by(grouping_factors + ["time_end"])
+    #     .agg(pl.col("estimate").mean().alias("estimate"))
+    #     .sort("time_end")
+    # )
 
     return cumulative_projections
 

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -9,8 +9,8 @@ alt.data_transformers.disable_max_rows()
 
 def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):
     """
-    Save a multiple-grid graph with the comparison between the observed uptake and the prediction,
-    initiated over the season.
+    Save a multiple-grid graph with the comparison between the observed uptake and the individual prediction projections,
+    grouped by forecast start and model.
 
     Arguments:
     --------------
@@ -19,6 +19,8 @@ def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):
     pred: polars.Dataframe
         The predicted daily uptake, differed by forecast date, must include columns
         `forecast_start` and `estimate`.
+    config: yaml
+        config file to specify grouping factors.
 
     Return:
     -------------
@@ -37,31 +39,10 @@ def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):
     plot_obs = (
         obs.join(models_forecasts, how="cross")
         .with_columns(type=pl.lit("obs"))
-        .select(
-            [
-                "type",
-                "model",
-                "forecast_start",
-                "time_end",
-                "estimate",
-                "season",
-                "sample_id",
-            ]
-        )
         .filter(pl.col("season").is_in(pred["season"].unique()))
     )
 
-    plot_pred = pred.with_columns(pl.lit("pred").alias("type")).select(
-        [
-            "type",
-            "model",
-            "forecast_start",
-            "time_end",
-            "estimate",
-            "season",
-            "sample_id",
-        ]
-    )
+    plot_pred = pred.with_columns(pl.lit("pred").alias("type")).select(plot_obs.columns)
 
     plot_data = pl.concat([plot_obs, plot_pred])
 
@@ -115,35 +96,10 @@ def plot_summary(obs, pred):
     plot_obs = (
         obs.join(models_forecasts, how="cross")
         .with_columns(type=pl.lit("obs"))
-        .select(
-            [
-                "type",
-                "model",
-                "forecast_start",
-                "time_end",
-                "estimate",
-                "season",
-                "sample_id",
-            ]
-        )
         .filter(pl.col("season").is_in(pred["season"].unique()))
     )
 
-    plot_pred = (
-        pred.with_columns(pl.lit("pred").alias("type"))
-        .select(
-            [
-                "type",
-                "model",
-                "forecast_start",
-                "time_end",
-                "estimate",
-                "season",
-                "sample_id",
-            ]
-        )
-        .sort("time_end")
-    )
+    plot_pred = pred.with_columns(pl.lit("pred").alias("type")).select(plot_obs.columns)
 
     plot_data = pl.concat([plot_obs, plot_pred])
 

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -4,8 +4,8 @@ import altair as alt
 
 alt.data_transformers.disable_max_rows()
 
-from altair import datum
 import polars as pl
+from altair import datum
 
 
 def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -1,11 +1,10 @@
 import argparse
 
 import altair as alt
-
-alt.data_transformers.disable_max_rows()
-
 import polars as pl
 from altair import datum
+
+alt.data_transformers.disable_max_rows()
 
 
 def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -1,13 +1,15 @@
 import argparse
 
 import altair as alt
+import numpy as np
 import polars as pl
+import yaml
 from altair import datum
 
 alt.data_transformers.disable_max_rows()
 
 
-def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):
+def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame, config: dict):
     """
     Save a multiple-grid graph with the comparison between the observed uptake and the individual prediction projections,
     grouped by forecast start and model.
@@ -20,16 +22,24 @@ def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):
         The predicted daily uptake, differed by forecast date, must include columns
         `forecast_start` and `estimate`.
     config: yaml
-        config file to specify grouping factors.
+        The config file specifying the number of prediction trajectories to plot.
 
     Return:
     -------------
-    chart object
+        altair chart object
     """
 
     # input check
     if "time_end" not in obs.columns or "estimate" not in obs.columns:
         ValueError("'time_end' or 'estimate' is missing from obs.")
+
+    sample_ids = pred["sample_id"].unique()
+
+    rng = np.random.default_rng()
+
+    selected_ids = rng.choice(sample_ids, size=config["prediction"]["n_samples"])
+
+    pred = pred.filter(pl.col("sample_id").is_in(selected_ids))
 
     # get every model/forecast date combo
     models_forecasts = pred.select(["model", "forecast_start", "sample_id"]).unique()
@@ -61,7 +71,7 @@ def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):
 
     pred_chart = (
         alt.Chart()
-        .mark_line()
+        .mark_line(opacity=0.3)
         .encode(
             alt.X(
                 "time_end:T",
@@ -78,7 +88,26 @@ def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):
     )
 
 
-def plot_summary(obs, pred):
+def plot_summary(obs: pl.DataFrame, pred: pl.DataFrame, config: dict):
+    """
+    Save a multiple-grid graph of observed data and mean, interval estimate of prediction
+    posterior distribution, grouped by model and forecast start.
+
+    Arguments:
+    --------------
+    obs: polars.Dataframe
+        The observed uptake data frame, indicating the cumulative vaccine uptake as of `time_end`.
+    pred: polars.Dataframe
+        The predicted daily uptake, differed by forecast date, must include columns
+        `forecast_start` and `estimate`.
+    config: yaml
+        config file to specify the lower and upper bounds of credible interval to plot.
+
+    Return:
+    -------------
+        altair chart object
+    """
+
     # input check
     if "time_end" not in obs.columns or "estimate" not in obs.columns:
         ValueError("'time_end' or 'estimate' is missing from obs.")
@@ -95,7 +124,7 @@ def plot_summary(obs, pred):
 
     plot_data = pl.concat([plot_obs, plot_pred])
 
-    obs = (
+    obs_chart = (
         alt.Chart(plot_data)
         .mark_point(color="black", filled=True)
         .encode(
@@ -108,12 +137,16 @@ def plot_summary(obs, pred):
         .transform_filter(datum.type == "obs")
     )
 
-    interval = (
+    interval_chart = (
         alt.Chart(plot_data)
         .transform_filter(datum.type == "pred")
         .transform_quantile(
             "estimate",
-            probs=[0.0025, 0.5, 0.975],
+            probs=[
+                config["prediction"]["interval"]["lower"],
+                0.5,
+                config["prediction"]["interval"]["upper"],
+            ],
             as_=["quantile", "estimate"],
             groupby=["time_end", "season", "forecast_start", "model"],
         )
@@ -121,7 +154,7 @@ def plot_summary(obs, pred):
         .encode(x="time_end:T", y="estimate:Q", color="quantile:N")
     )
 
-    return alt.layer(interval, obs, data=plot_data).facet(
+    return alt.layer(interval_chart, obs_chart, data=plot_data).facet(
         column="model", row="forecast_start"
     )
 
@@ -134,12 +167,10 @@ def plot_score(scores: pl.DataFrame):
     --------------
     scores: polars.DataFrame
         The evaluation scores data frame.
-    config: dict
-        config.yaml to decide if plot or not.
 
     Return:
     -------------
-    chart object
+        altair.chart object
     """
     score_names = scores["score_fun"].unique()
 
@@ -171,13 +202,18 @@ if __name__ == "__main__":
     p.add_argument("--score", help="evaluation scores")
     p.add_argument("--proj_output", help="png file of projection plot")
     p.add_argument("--score_output", help="png file of score plot")
+    p.add_argument("--config", help="config file")
     p.add_argument("--summary_output", help="png file of mean and 95% CI plot")
     args = p.parse_args()
 
     pred = pl.read_parquet(args.pred)
     data = pl.read_parquet(args.obs)
-    plot_individual_projections(data, pred).save(args.proj_output)
-    plot_summary(data, pred).save(args.summary_output)
+
+    with open(args.config, "r") as f:
+        config = yaml.safe_load(f)
+
+    plot_individual_projections(data, pred, config).save(args.proj_output)
+    plot_summary(data, pred, config).save(args.summary_output)
 
     # score = pl.read_parquet(args.score)
     # plot_score(score).save(args.score_output)

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -46,16 +46,8 @@ def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):
 
     plot_data = pl.concat([plot_obs, plot_pred])
 
-    plot_new_data = plot_data.filter(
-        pl.col("time_end").is_between(
-            pl.col("forecast_start").min(),
-            pl.col("forecast_start").max(),
-            "both",
-        )
-    )
-
     obs_chart = (
-        alt.Chart(plot_new_data)
+        alt.Chart(plot_data)
         .mark_point(filled=True, color="black")
         .encode(
             alt.X(
@@ -81,7 +73,7 @@ def plot_individual_projections(obs: pl.DataFrame, pred: pl.DataFrame):
         .transform_filter(datum.type == "pred")
     )
 
-    return alt.layer(pred_chart, obs_chart, data=plot_new_data).facet(
+    return alt.layer(pred_chart, obs_chart, data=plot_data).facet(
         column="model", row="forecast_start"
     )
 
@@ -103,16 +95,8 @@ def plot_summary(obs, pred):
 
     plot_data = pl.concat([plot_obs, plot_pred])
 
-    plot_new_data = plot_data.filter(
-        pl.col("time_end").is_between(
-            pl.col("forecast_start").min(),
-            pl.col("forecast_start").max(),
-            "both",
-        )
-    )
-
     obs = (
-        alt.Chart(plot_new_data)
+        alt.Chart(plot_data)
         .mark_point(color="black", filled=True)
         .encode(
             alt.X(
@@ -125,7 +109,7 @@ def plot_summary(obs, pred):
     )
 
     interval = (
-        alt.Chart(plot_new_data)
+        alt.Chart(plot_data)
         .transform_filter(datum.type == "pred")
         .transform_quantile(
             "estimate",
@@ -137,7 +121,7 @@ def plot_summary(obs, pred):
         .encode(x="time_end:T", y="estimate:Q", color="quantile:N")
     )
 
-    return alt.layer(interval, obs, data=plot_new_data).facet(
+    return alt.layer(interval, obs, data=plot_data).facet(
         column="model", row="forecast_start"
     )
 


### PR DESCRIPTION
- Add `plot_individual_projections`  in `postprocess.py` to allow plotting individual samples vs data. 
- Add `plot_summary` in `postprocess.py` to allow plotting mean, 95% credible interval with data. 
   Currently, line plot is used instead of area because the challenge of using alt.area on pivotted quantile data. This is my trial code (no error but only returned blank):

```
interval = alt.Chart(plot_new_data).transform_filter(
       datum.type == 'pred'
).transform_quantile(
      "estimate",probs = [0.0025,0.5,0.975],as_=["quantile","estimate"],  # Calculate quantile for each grouping factor #
       groupby=["time_end","season","forecast_start","model"]
).transform_pivot(
      "quantile", groupby=["time_end"], value="estimate" # Convert long data frame to wide data frame #
).mark_area(opacity=0.3,color = "blue").encode(
        x="time_end:T",
        y="0.025:Q",
        y2="0.975:Q",
)

```
I think the error is that the new columns is named as a quantile number (0.0025,0.975), since a plot was returned if the new column name is a string. Similar question has been asked [online](https://stackoverflow.com/questions/68515371/plot-area-between-two-quantiles-in-altair) but hasn't been resolved.

Another way is that we manually transform the data frame and feed to altair. But before that I would like to know if you have any ideas to fix this!

- Modify Makefile to allow generating plot directly. The commented line will be useful and added once the interval metrics are added. 

If running smoothly, two plots are expected:

Individual plot (400 trajectories):

![image](https://github.com/user-attachments/assets/db71e0c7-d630-411a-84f5-14aa3562fa19)

Summary plot: 

![image](https://github.com/user-attachments/assets/cdf33ab0-e557-4365-a19a-d4dbcce9069d)

