### PR TITLE
Refactor Hill Model, again

### DIFF
--- a/docs/model_details.md
+++ b/docs/model_details.md
@@ -1,10 +1,12 @@
 # Overview
 
-This is a summary of the models used to capture and forecast vaccine uptake. There are currently two models: an autoregressive and a Hill function. Each model proposes a latent true uptake curve, which is subject to observation error. Each model uses a hierarchy to account for grouping factors (e.g. season, geography, age, and/or race). In particular, the parameters governing the latent true uptake curve for each group (a combination of one value of each grouping factor) are given by baseline values plus deviations drawn from distributions representing each grouping factor.
+This is a summary of the models used to capture and forecast vaccine uptake. There are currently two models: an autoregressive and a mixed Hill/linear function. Each model proposes a latent true uptake curve, which is subject to observation error. Each model uses a hierarchy to account for grouping factors (e.g. season, geography, age, and/or race). In particular, the parameters governing the latent true uptake curve for each group (a combination of one value of each grouping factor) are given by baseline values plus deviations drawn from distributions representing each grouping factor.
 
-# Notation
+# Autoregressive Model
 
-The following notation will be used across all models
+## Notation
+
+The following notation will be used for the autoregressive model:
 - $t$ = number of days since rollout (i.e. $t_0$)
 - $t_0$ = rollout, i.e. the last day before the vaccine was available
 - $c_t^{obs}$ = observed cumulative uptake on day $t$
@@ -13,7 +15,7 @@ The following notation will be used across all models
 - $u_t$ = latent true incident uptake between days $t-1$ and $t$, i.e. $c_t - c_{t-1}$
 - $G$ = grouping factors (e.g. season, geographic area, age group, race/ethnicity), indexed by $i$ with $I$ total factors
 
-# Autoregressive Model
+## Summary
 
 At a high level, the autoregressive (AR) model is structured as follows:
 
@@ -76,26 +78,37 @@ and similarly for $\beta$, $\gamma$, and $\theta$. Additionally:
 \end{align*}
 ```
 
-# Hill Model
+# Hill/Linear Model
+
+## Notation
+
+The following notation will be used for the Hill/linear model:
+- $t$ = time since rollout, expressed as the fraction of a year elapsed since the start of the season
+- $V_t^{obs}$ = number of people surveyed at time $t$ who are vaccinated
+- $N_t^{obs}$ = total number of people surveyed at time $t$
+- $c_t$ = latent true cumulative uptake on day $t$
+- $G$ = grouping factors (e.g. season, geographic area, age group, race/ethnicity), indexed by $i$ with $I$ total factors
+
+## Summary
 
 At a high level, the Hill model is structured as follows:
 
 ```math
 \begin{align*}
-&c_{t,G}^{obs} \sim \text{Pr}(c_{t,G}^{obs}~|~c_{t,G},~\sigma_G^{obs}) \\
-&c_{t,G} := f_{\text{Hill}}(t,~\phi_G) \\
+&Z_{t,G}^{obs} \sim \text{Pr}(Z_{t,G}^{obs}~|~c_{t,G},~N_{t,G}^{obs}) \\
+&c_{t,G} := f_{\text{Hill, Linear}}(t,~\phi_G) \\
 &\phi_G \sim \text{Pr}(\phi_G~|~\xi) \\
 &\xi \sim \text{Pr}(\xi) \\
 \end{align*}
 ```
 
-For the Hill model, $t$ is rescaled by dividing by 365, so that $t$ represents the proportion of a season elapsed. This is not a problem because $t$ need not be an integer here, and it helps keep all parameters on a similar scale. More details on the Hill model are given below.
+Here, $t$ is rescaled by dividing by 365, so that $t$ represents the proportion of a season elapsed. Additionally, $Z_{t,G}^{obs}$ and $N_{t,G}^{obs}$ are inferred from $c_{t,G}^{obs}$ and its reported 95% confidence interval, by assuming the latter is a Wald interval representing $1.96$ standard errors of the mean in each direction from $c_{t,G}^{obs}$.
 
 ## Observation Layer
 
 ```math
 \begin{align*}
-&c_{t,G_1,...,G_I}^{obs} \sim \text{TruncNorm}(\text{location = }c_{t,G_1,...,G_I}, \text{ scale = }\sigma_{t,G_1,...,G_I}^{obs}, \text{ lower = }0, \text{ upper = }1) \\
+&Z_{t,G_1,...,G_I}^{obs} \sim \text{BetaBinomial}(\text{shape1 = }\alpha_{t,G_1,...,G_I}, \text{ shape2 = }\beta, \text{ N = }N_{t,G_1,...,G_I}^{obs}) \\
 \end{align*}
 ```
 
@@ -103,7 +116,8 @@ For the Hill model, $t$ is rescaled by dividing by 365, so that $t$ represents t
 
 ```math
 \begin{align*}
-&c_{t,G_1,...,G_I} = \frac{A_{G_1,...,G_I} \cdot t^{n}}{H_{G_1,...,G_I}^{n} + t^{n}} \\
+&c_{t,G_1,...,G_I} = \frac{A_{G_1,...,G_I} \cdot t^{n}}{H^{n} + t^{n}} + M_{G_1,...,G_I} \cdot t \\
+&\alpha_{t,G_1,...,G_I} = \frac{c_{t,G_1,...,G_I}}{1 - c_{t,G_1,...,G_I}} \cdot \beta \\
 \end{align*}
 ```
 
@@ -116,16 +130,18 @@ For the Hill model, $t$ is rescaled by dividing by 365, so that $t$ represents t
 \end{align*}
 ```
 
-and similarly for $H$.
+and similarly for $M$.
 
 ## Priors
 
 ```math
 \begin{align*}
-&A \sim \text{Beta}(\text{shape1 = }15.0, \text{ shape2 = }20.0) \\
-&H \sim \text{Beta}(\text{shape1 = }25.0, \text{ shape2 = }50.0) \\
+&A \sim \text{Beta}(\text{shape1 = }100.0, \text{ shape2 = }140.0) \\
 &\sigma_{A_{G_i}} \sim \text{Exponential}(\text{rate = }40.0) ~\forall~i~\text{ in } 1, ..., I \\
-&\sigma_{H_{G_i}} \sim \text{Exponential}(\text{rate = }40.0) ~\forall~i~\text{ in } 1, ..., I \\
+&H \sim \text{Beta}(\text{shape1 = }100.0, \text{ shape2 = }225.0) \\
 &n \sim \text{Gamma}(\text{shape = }20.0, \text{ rate = }5.0) \\
+&M \sim \text{Gamma}(\text{shape = }1.0, \text{ rate = }0.1) \\
+&\sigma_{M_{G_i}} \sim \text{Exponential}(\text{rate = }40.0) ~\forall~i~\text{ in } 1, ..., I \\
+&\beta \sim \text{Gamma}(\text{shape = }5.0, \text{ rate = }0.05) \\
 \end{align*}
 ```

--- a/docs/model_journal.md
+++ b/docs/model_journal.md
@@ -26,6 +26,14 @@ With estimates of pN and N in hand, the observation process was replaced with a 
 
 Even with MCMC proceeding, other warning signs arose:
 - When grouping on season alone, season-specific deviations in both A and H from their overall averages have very wide 95% credible intervals, straddling 0. And yet, it is clear that uptake curves do differ from one another across seasons.
-- When grouping on season and state, the fitting proceeds very slowly (1-2 it/s). A, A deviations by season, H, and H deviations by season all had very low ESS (40-60, despite 500 samples after warmup). A deviations by state had even lower ESS (10-15). H deviations by state had higher ESS, but the magnitude in variation in H among states was estimated very close to 0.
+- When grouping on season and state, the fitting proceeds very slowly (1-2 it/s). A, A-deviations-by-season, H, and H-deviations-by-season all had very low ESS (40-60, despite 500 samples after warmup). A-deviations-by-state had even lower ESS (10-15). H-deviations-by-state had higher ESS, but the magnitude in variation in H among states was estimated very close to 0.
 
 Together, these warning signs suggest some non-identifiability among the parameters that vary by grouping factor, perhaps again driven by the poor fit of the Hill function to uptake curves.
+
+## Solution Pt 2: Hill + Linear Functions
+
+Many warning signs were alleviated by changing the structure of the latent true uptake from a pure Hill function to a Hill function plus a slope-only linear function (intercept = 0). In this model, the linear slope "M" and the Hill asymptote "A" can deviate additively from their overall averages by group, while the Hill midpoint "H" and steepness "n" are fixed across groups. In particular, this mixed function allows uptake to continue creeping upward late in a season.
+
+When grouping on season and state, the fitting still proceeds slowly (1-2 it/s), but only A and A-deviations-by-state have low ESS (50-100, with 500 samples after warmup). A-deviations-by-season, M, and M-deviations-by-state/season all have good ESS (100-500+). The magnitudes of A- and M-deviations are confidently estimated greater than 0. The 95% credible intervals for A- and M-deviations from the overall average often do not overlap 0, for many states and seasons. There are 0 divergences.
+
+The more promising aspects of the MCMC summary likely reflect a more appropriate fit of the latent true uptake model to the shape of the data.

--- a/docs/model_journal.md
+++ b/docs/model_journal.md
@@ -1,0 +1,31 @@
+# Overview
+
+Choosing a model structure has been trickier than expected. This is an informal record of the attempts that have been made, their outcomes, and consequent directions.
+
+# Cumulative S Curves
+
+The Scenarios team would like to use vaccine uptake forecasts as input for their ODE models. For this purpose, they need uptake curves that are continuously differentiable, not forecasts that are a series of point estimates. Autoregressive and stochastic models are not suitable for this purpose. Consequently, families of S-curves that directly model cumulative uptake will be prioritized, starting with the Hill function.
+
+# Hill Function
+
+In brief, the original Hill function model considers latent true uptake to follow a Hill curve shape. The final uptake and midpoint parameters ("A" and "H", respectively) can deviate additively from their overall averages based on grouping factors (e.g. season, state), while the steepness parameter ("n") only has one overall value. Observed uptake is centered on the latent true uptake but may have error in either direction. The magnitude of this error is derived from the 95% confidence interval reported along with each point estimate in the NIS data.
+
+## Trouble Pt. 1: Truncated Normal Observation
+
+The Hill model would not fit - the MCMC chains remained stationary and returned hundreds of identical draws with ESS = 1.0. This happened whether grouping factors were included or not (i.e. one curve fit across all seasons at the national scale). The stationary chains were solved by ignoring the empirical estimates of observation error: when observation error was fixed at a generous value (0.03) or was fit as a free parameter, the MCMC chais were no longer stationary.
+
+Why did empirical observation error break MCMC? The original Hill model used a truncated Normal draw to describe the observation process. The reported 95% confidence intervals were assumed to be Wald intervals, such that an interval's half-width divided by 1.96 approximates the standard deviation of the truncated Normal. These standard deviations were often on the order of 0.001, implying that the observed uptake curves are very close to the latent true uptake. But the Hill function does not fit the data that well: especially in the latter half of seasons, true uptake continues creeping upward while the Hill function asymptotes. Thus, no parameter set exists that can get the Hill function close enough to all data points, and MCMC gets stuck in flat portions of the likelihood landscape.
+
+## Solution Pt. 1: Beta-Binomial Observation
+
+MCMC chains were unstuck by reinterpretting the empirical confidence intervals in terms of the actual data collection process. Cumulative uptake is estimated by the proportion p of N phone survey participants who report being vaccinated. By considering an interval's half-width divided by 1.96 to be the standard error of the mean (SEM) for the reported uptake proportion p, N was estimated at each data point. Sensibly, stimated N is on the order of 1,000 for individual states and 50,000 at the national scale.
+
+With estimates of pN and N in hand, the observation process was replaced with a beta-binomial likelihood, which inherently permits observations to vary farther from the latent true uptake, compared to the truncated Normal likelihood. Consequently, the MCMC chains began sampling parameter space more freely.
+
+## Trouble Pt. 2: Hill Function Shape
+
+Even with MCMC proceeding, other warning signs arose:
+- When grouping on season alone, season-specific deviations in both A and H from their overall averages have very wide 95% credible intervals, straddling 0. And yet, it is clear that uptake curves do differ from one another across seasons.
+- When grouping on season and state, the fitting proceeds very slowly (1-2 it/s). A, A deviations by season, H, and H deviations by season all had very low ESS (40-60, despite 500 samples after warmup). A deviations by state had even lower ESS (10-15). H deviations by state had higher ESS, but the magnitude in variation in H among states was estimated very close to 0.
+
+Together, these warning signs suggest some non-identifiability among the parameters that vary by grouping factor, perhaps again driven by the poor fit of the Hill function to uptake curves.

--- a/iup/models.py
+++ b/iup/models.py
@@ -2,6 +2,7 @@ import abc
 import datetime as dt
 from typing import List
 
+# import jax.numpy as jnp
 import numpy as np
 import numpyro
 import numpyro.distributions as dist
@@ -644,6 +645,91 @@ class HillModel(UptakeModel):
         """
         self.rng_key = random.PRNGKey(seed)
         self.model = HillModel.hill
+
+    # @staticmethod
+    # def hill(
+    #     elapsed,
+    #     N_vax=None,
+    #     N_tot=None,
+    #     groups=None,
+    #     num_group_factors=0,
+    #     num_group_levels=[0],
+    #     A_shape1=15.0,
+    #     A_shape2=20.0,
+    #     A_sig=40.0,
+    #     H_shape1=25.0,
+    #     H_shape2=50.0,
+    #     H_sig=40.0,
+    #     n_shape=20.0,
+    #     n_rate=5.0,
+    #     S2_shape=10.0,
+    #     S2_rate=5.0,
+    # ):
+    #     """
+    #     Fit a Hill model on training data.
+
+    #     Parameters
+    #     elapsed: np.array
+    #         column of days elapsed since the season start for each data point
+    #     N_vax: np.array | None
+    #         column of number of people vaccinated at each data point
+    #     N_tot: np.array | None
+    #         column of number of people contacted at each data point
+    #     groups: np.array | None
+    #         numeric codes for groups: row = data point, col = grouping factor
+    #     num_group_factors: Int
+    #         number of grouping factors
+    #     num_group_levels: List[Int,]
+    #         number of unique levels of each grouping factor
+    #     other parameters: float
+    #         parameters to specify the prior distributions
+
+    #     Returns
+    #     Nothing
+
+    #     Details
+    #     Provides the model structure and priors for a Hill model.
+    #     """
+    #     # Sample the overall average value for each Hill function parameter
+    #     A = numpyro.sample("A", dist.Beta(A_shape1, A_shape2))
+    #     H = numpyro.sample("H", dist.Beta(H_shape1, H_shape2))
+    #     S2 = numpyro.sample("S2", dist.Gamma(S2_shape, S2_rate))
+    #     # If grouping factors are given, find the specific A and H for each datum
+    #     if groups is not None:
+    #         # Draw a sample of the spread among levels for each grouping factor
+    #         A_sigs = numpyro.sample(
+    #             "A_sigs", dist.Exponential(A_sig), sample_shape=(num_group_factors,)
+    #         )
+    #         H_sigs = numpyro.sample(
+    #             "H_sigs", dist.Exponential(H_sig), sample_shape=(num_group_factors,)
+    #         )
+    #         # Draw deviations from the overall average A and H for each level
+    #         # of each grouping factor and scale them by the characteristic spread
+    #         # for each grouping factor
+    #         A_devs = numpyro.sample(
+    #             "A_devs", dist.Normal(0, 1), sample_shape=(sum(num_group_levels),)
+    #         ) * np.repeat(A_sigs, np.array(num_group_levels))
+    #         H_devs = H_devs = numpyro.sample(
+    #             "H_devs", dist.Normal(0, 1), sample_shape=(sum(num_group_levels),)
+    #         ) * np.repeat(H_sigs, np.array(num_group_levels))
+    #         # Across all data points, look up the A and H deviations due to the
+    #         # grouping factors. Sum across grouping factors and include the overall
+    #         # average A and H to get the final total A and H for each datum
+    #         A_tot = np.sum(A_devs[groups], axis=1) + A
+    #         H_tot = np.sum(H_devs[groups], axis=1) + H
+    #         # Calculate the postulated latent true uptake given the time elapsed at
+    #         # each datum, accounting for the final total A and H values
+    #         mu = 1 - 1 / (
+    #             jnp.cosh(
+    #                 A_tot * (1 - (elapsed**H_tot) / jnp.tanh(elapsed**H_tot)) / H_tot
+    #             )
+    #         )
+    #     else:
+    #         # Without grouping factors, use the same A and H across all data
+    #         mu = 1 - 1 / (jnp.cosh(A * (1 - (elapsed**H) / jnp.tanh(elapsed**H)) / H))
+    #     # Calculate the first shape parameter for the beta-binomial likelihood
+    #     S1 = (mu / (1 - mu)) * S2
+    #     numpyro.sample("obs", dist.BetaBinomial(S1, S2, N_tot), obs=N_vax)
 
     @staticmethod
     def hill(

--- a/iup/models.py
+++ b/iup/models.py
@@ -978,7 +978,8 @@ class HillModel(UptakeModel):
             elapsed=iup.utils.date_to_elapsed(
                 pl.col("time_end"), season_start_month, season_start_day
             )
-            / 365
+            / 365,
+            N_tot=pl.lit(1000),
         ).drop("estimate")
 
         return scaffold
@@ -1051,6 +1052,7 @@ class HillModel(UptakeModel):
                 predictive(
                     self.rng_key,
                     elapsed=scaffold["elapsed"].to_numpy(),
+                    N_tot=scaffold["N_tot"].to_numpy(),
                     groups=group_codes,
                     num_group_factors=self.num_group_factors,
                     num_group_levels=self.num_group_levels,

--- a/iup/models.py
+++ b/iup/models.py
@@ -631,7 +631,7 @@ class LinearIncidentUptakeModel(UptakeModel):
 
 class HillModel(UptakeModel):
     """
-    Subclass of UptakeModel for a Hill function model.
+    Subclass of UptakeModel for a mixed Hill + Linear model.
     For details, see: <https://github.com/CDCgov/cfa-immunization-uptake-projection/blob/main/docs/model_details.md>
     """
 
@@ -646,91 +646,6 @@ class HillModel(UptakeModel):
         self.rng_key = random.PRNGKey(seed)
         self.model = HillModel.hill
 
-    # @staticmethod
-    # def hill(
-    #     elapsed,
-    #     N_vax=None,
-    #     N_tot=None,
-    #     groups=None,
-    #     num_group_factors=0,
-    #     num_group_levels=[0],
-    #     A_shape1=15.0,
-    #     A_shape2=20.0,
-    #     A_sig=40.0,
-    #     H_shape1=25.0,
-    #     H_shape2=50.0,
-    #     H_sig=40.0,
-    #     n_shape=20.0,
-    #     n_rate=5.0,
-    #     S2_shape=10.0,
-    #     S2_rate=5.0,
-    # ):
-    #     """
-    #     Fit a Hill model on training data.
-
-    #     Parameters
-    #     elapsed: np.array
-    #         column of days elapsed since the season start for each data point
-    #     N_vax: np.array | None
-    #         column of number of people vaccinated at each data point
-    #     N_tot: np.array | None
-    #         column of number of people contacted at each data point
-    #     groups: np.array | None
-    #         numeric codes for groups: row = data point, col = grouping factor
-    #     num_group_factors: Int
-    #         number of grouping factors
-    #     num_group_levels: List[Int,]
-    #         number of unique levels of each grouping factor
-    #     other parameters: float
-    #         parameters to specify the prior distributions
-
-    #     Returns
-    #     Nothing
-
-    #     Details
-    #     Provides the model structure and priors for a Hill model.
-    #     """
-    #     # Sample the overall average value for each Hill function parameter
-    #     A = numpyro.sample("A", dist.Beta(A_shape1, A_shape2))
-    #     H = numpyro.sample("H", dist.Beta(H_shape1, H_shape2))
-    #     S2 = numpyro.sample("S2", dist.Gamma(S2_shape, S2_rate))
-    #     # If grouping factors are given, find the specific A and H for each datum
-    #     if groups is not None:
-    #         # Draw a sample of the spread among levels for each grouping factor
-    #         A_sigs = numpyro.sample(
-    #             "A_sigs", dist.Exponential(A_sig), sample_shape=(num_group_factors,)
-    #         )
-    #         H_sigs = numpyro.sample(
-    #             "H_sigs", dist.Exponential(H_sig), sample_shape=(num_group_factors,)
-    #         )
-    #         # Draw deviations from the overall average A and H for each level
-    #         # of each grouping factor and scale them by the characteristic spread
-    #         # for each grouping factor
-    #         A_devs = numpyro.sample(
-    #             "A_devs", dist.Normal(0, 1), sample_shape=(sum(num_group_levels),)
-    #         ) * np.repeat(A_sigs, np.array(num_group_levels))
-    #         H_devs = H_devs = numpyro.sample(
-    #             "H_devs", dist.Normal(0, 1), sample_shape=(sum(num_group_levels),)
-    #         ) * np.repeat(H_sigs, np.array(num_group_levels))
-    #         # Across all data points, look up the A and H deviations due to the
-    #         # grouping factors. Sum across grouping factors and include the overall
-    #         # average A and H to get the final total A and H for each datum
-    #         A_tot = np.sum(A_devs[groups], axis=1) + A
-    #         H_tot = np.sum(H_devs[groups], axis=1) + H
-    #         # Calculate the postulated latent true uptake given the time elapsed at
-    #         # each datum, accounting for the final total A and H values
-    #         mu = 1 - 1 / (
-    #             jnp.cosh(
-    #                 A_tot * (1 - (elapsed**H_tot) / jnp.tanh(elapsed**H_tot)) / H_tot
-    #             )
-    #         )
-    #     else:
-    #         # Without grouping factors, use the same A and H across all data
-    #         mu = 1 - 1 / (jnp.cosh(A * (1 - (elapsed**H) / jnp.tanh(elapsed**H)) / H))
-    #     # Calculate the first shape parameter for the beta-binomial likelihood
-    #     S1 = (mu / (1 - mu)) * S2
-    #     numpyro.sample("obs", dist.BetaBinomial(S1, S2, N_tot), obs=N_vax)
-
     @staticmethod
     def hill(
         elapsed,
@@ -739,30 +654,29 @@ class HillModel(UptakeModel):
         groups=None,
         num_group_factors=0,
         num_group_levels=[0],
-        A_shape1=15.0,
-        A_shape2=20.0,
+        A_shape1=100.0,
+        A_shape2=140.0,
         A_sig=40.0,
-        H_shape1=25.0,
-        H_shape2=50.0,
-        # H_sig=40.0,
+        H_shape1=100.0,
+        H_shape2=225.0,
         n_shape=20.0,
         n_rate=5.0,
         M_shape=1.0,
         M_rate=0.1,
         M_sig=40.0,
-        S2_shape=10.0,
-        S2_rate=5.0,
+        S2_shape=5.0,
+        S2_rate=0.5,
     ):
         """
-        Fit a Hill model on training data.
+        Fit a mixed Hill + Linear model on training data.
 
         Parameters
         elapsed: np.array
-            column of days elapsed since the season start for each data point
+            fraction of a year elapsed since the start of season at each data point
         N_vax: np.array | None
-            column of number of people vaccinated at each data point
+            number of people vaccinated at each data point
         N_tot: np.array | None
-            column of number of people contacted at each data point
+            number of people contacted at each data point
         groups: np.array | None
             numeric codes for groups: row = data point, col = grouping factor
         num_group_factors: Int
@@ -778,209 +692,36 @@ class HillModel(UptakeModel):
         Details
         Provides the model structure and priors for a Hill model.
         """
-        # Sample the overall average value for each Hill function parameter
+        # Sample the overall average value for each parameter
         A = numpyro.sample("A", dist.Beta(A_shape1, A_shape2))
         H = numpyro.sample("H", dist.Beta(H_shape1, H_shape2))
         n = numpyro.sample("n", dist.Gamma(n_shape, n_rate))
         M = numpyro.sample("M", dist.Gamma(M_shape, M_rate))
         S2 = numpyro.sample("S2", dist.Gamma(S2_shape, S2_rate))
-        # If grouping factors are given, find the specific A and H for each datum
+        # If grouping factors are given, find the group-specific deviations for each datum
         if groups is not None:
-            # Draw a sample of the spread among levels for each grouping factor
             A_sigs = numpyro.sample(
                 "A_sigs", dist.Exponential(A_sig), sample_shape=(num_group_factors,)
             )
             M_sigs = numpyro.sample(
                 "M_sigs", dist.Exponential(M_sig), sample_shape=(num_group_factors,)
             )
-            # Draw deviations from the overall average A and H for each level
-            # of each grouping factor and scale them by the characteristic spread
-            # for each grouping factor
             A_devs = numpyro.sample(
                 "A_devs", dist.Normal(0, 1), sample_shape=(sum(num_group_levels),)
             ) * np.repeat(A_sigs, np.array(num_group_levels))
             M_devs = M_devs = numpyro.sample(
                 "M_devs", dist.Normal(0, 1), sample_shape=(sum(num_group_levels),)
             ) * np.repeat(M_sigs, np.array(num_group_levels))
-            # Across all data points, look up the A and H deviations due to the
-            # grouping factors. Sum across grouping factors and include the overall
-            # average A and H to get the final total A and H for each datum
             A_tot = np.sum(A_devs[groups], axis=1) + A
             M_tot = np.sum(M_devs[groups], axis=1) + M
-            # Calculate the postulated latent true uptake given the time elapsed at
-            # each datum, accounting for the final total A and H values
+            # Calculate latent true uptake at each datum
             mu = A_tot * (elapsed**n) / (H**n + elapsed**n) + (M_tot * elapsed)
         else:
-            # Without grouping factors, use the same A and H across all data
+            # Calculate latent true uptake at each datum if no grouping factors
             mu = A * (elapsed**n) / (H**n + elapsed**n) + (M * elapsed)
         # Calculate the first shape parameter for the beta-binomial likelihood
         S1 = (mu / (1 - mu)) * S2
         numpyro.sample("obs", dist.BetaBinomial(S1, S2, N_tot), obs=N_vax)
-
-    # @staticmethod
-    # def hill(
-    #     elapsed,
-    #     N_vax=None,
-    #     N_tot=None,
-    #     groups=None,
-    #     num_group_factors=0,
-    #     num_group_levels=[0],
-    #     A_shape1=15.0,
-    #     A_shape2=20.0,
-    #     A_sig=40.0,
-    #     H_shape1=25.0,
-    #     H_shape2=50.0,
-    #     H_sig=40.0,
-    #     n_shape=20.0,
-    #     n_rate=5.0,
-    #     S2_shape=10.0,
-    #     S2_rate=5.0,
-    # ):
-    #     """
-    #     Fit a Hill model on training data.
-
-    #     Parameters
-    #     elapsed: np.array
-    #         column of days elapsed since the season start for each data point
-    #     N_vax: np.array | None
-    #         column of number of people vaccinated at each data point
-    #     N_tot: np.array | None
-    #         column of number of people contacted at each data point
-    #     groups: np.array | None
-    #         numeric codes for groups: row = data point, col = grouping factor
-    #     num_group_factors: Int
-    #         number of grouping factors
-    #     num_group_levels: List[Int,]
-    #         number of unique levels of each grouping factor
-    #     other parameters: float
-    #         parameters to specify the prior distributions
-
-    #     Returns
-    #     Nothing
-
-    #     Details
-    #     Provides the model structure and priors for a Hill model.
-    #     """
-    #     # Sample the overall average value for each Hill function parameter
-    #     A = numpyro.sample("A", dist.Beta(A_shape1, A_shape2))
-    #     H = numpyro.sample("H", dist.Beta(H_shape1, H_shape2))
-    #     n = numpyro.sample("n", dist.Gamma(n_shape, n_rate))
-    #     S2 = numpyro.sample("S2", dist.Gamma(S2_shape, S2_rate))
-    #     # If grouping factors are given, find the specific A and H for each datum
-    #     if groups is not None:
-    #         # Draw a sample of the spread among levels for each grouping factor
-    #         A_sigs = numpyro.sample(
-    #             "A_sigs", dist.Exponential(A_sig), sample_shape=(num_group_factors,)
-    #         )
-    #         H_sigs = numpyro.sample(
-    #             "H_sigs", dist.Exponential(H_sig), sample_shape=(num_group_factors,)
-    #         )
-    #         # Draw deviations from the overall average A and H for each level
-    #         # of each grouping factor and scale them by the characteristic spread
-    #         # for each grouping factor
-    #         A_devs = numpyro.sample(
-    #             "A_devs", dist.Normal(0, 1), sample_shape=(sum(num_group_levels),)
-    #         ) * np.repeat(A_sigs, np.array(num_group_levels))
-    #         H_devs = H_devs = numpyro.sample(
-    #             "H_devs", dist.Normal(0, 1), sample_shape=(sum(num_group_levels),)
-    #         ) * np.repeat(H_sigs, np.array(num_group_levels))
-    #         # Across all data points, look up the A and H deviations due to the
-    #         # grouping factors. Sum across grouping factors and include the overall
-    #         # average A and H to get the final total A and H for each datum
-    #         A_tot = np.sum(A_devs[groups], axis=1) + A
-    #         H_tot = np.sum(H_devs[groups], axis=1) + H
-    #         # Calculate the postulated latent true uptake given the time elapsed at
-    #         # each datum, accounting for the final total A and H values
-    #         mu = A_tot * (elapsed**n) / (H_tot**n + elapsed**n)
-    #     else:
-    #         # Without grouping factors, use the same A and H across all data
-    #         mu = A * (elapsed**n) / (H**n + elapsed**n)
-    #     # Calculate the first shape parameter for the beta-binomial likelihood
-    #     S1 = (mu / (1 - mu)) * S2
-    #     numpyro.sample("obs", dist.BetaBinomial(S1, S2, N_tot), obs=N_vax)
-
-    # @staticmethod
-    # def hill(
-    #     elapsed,
-    #     cum_uptake=None,
-    #     std_dev=None,
-    #     groups=None,
-    #     num_group_factors=0,
-    #     num_group_levels=[0],
-    #     A_shape1=15.0,
-    #     A_shape2=20.0,
-    #     A_sig=40.0,
-    #     H_shape1=25.0,
-    #     H_shape2=50.0,
-    #     H_sig=40.0,
-    #     n_shape=20.0,
-    #     n_rate=5.0,
-    # ):
-    #     """
-    #     Fit a Hill model on training data.
-
-    #     Parameters
-    #     elapsed: np.array
-    #         column of days elapsed since the season start for each data point
-    #     cum_uptake: np.array | None
-    #         column of cumulative uptake measured at each data point
-    #     std_dev: np.array | None
-    #         column of standard deviations in cumulative uptake estimate
-    #     groups: np.array | None
-    #         numeric codes for groups: row = data point, col = grouping factor
-    #     num_group_factors: Int
-    #         number of grouping factors
-    #     num_group_levels: List[Int,]
-    #         number of unique levels of each grouping factor
-    #     other parameters: float
-    #         parameters to specify the prior distributions
-
-    #     Returns
-    #     Nothing
-
-    #     Details
-    #     Provides the model structure and priors for a Hill model.
-    #     """
-    #     # Sample the overall average value for each Hill function parameter
-    #     A = numpyro.sample("A", dist.Beta(A_shape1, A_shape2))
-    #     H = numpyro.sample("H", dist.Beta(H_shape1, H_shape2))
-    #     n = numpyro.sample("n", dist.Gamma(n_shape, n_rate))
-    #     # If grouping factors are given, find the specific A and H for each datum
-    #     if groups is not None:
-    #         # Draw a sample of the spread among levels for each grouping factor
-    #         A_sigs = numpyro.sample(
-    #             "A_sigs", dist.Exponential(A_sig), sample_shape=(num_group_factors,)
-    #         )
-    #         H_sigs = numpyro.sample(
-    #             "H_sigs", dist.Exponential(H_sig), sample_shape=(num_group_factors,)
-    #         )
-    #         # Draw deviations from the overall average A and H for each level
-    #         # of each grouping factor and scale them by the characteristic spread
-    #         # for each grouping factor
-    #         A_devs = numpyro.sample(
-    #             "A_devs", dist.Normal(0, 1), sample_shape=(sum(num_group_levels),)
-    #         ) * np.repeat(A_sigs, np.array(num_group_levels))
-    #         H_devs = H_devs = numpyro.sample(
-    #             "H_devs", dist.Normal(0, 1), sample_shape=(sum(num_group_levels),)
-    #         ) * np.repeat(H_sigs, np.array(num_group_levels))
-    #         # Across all data points, look up the A and H deviations due to the
-    #         # grouping factors. Sum across grouping factors and include the overall
-    #         # average A and H to get the final total A and H for each datum
-    #         A_tot = np.sum(A_devs[groups], axis=1) + A
-    #         H_tot = np.sum(H_devs[groups], axis=1) + H
-    #         # Calculate the postulated latent true uptake given the time elapsed at
-    #         # each datum, accounting for the final total A and H values
-    #         mu = A_tot * (elapsed**n) / (H_tot**n + elapsed**n)
-    #     else:
-    #         # Without grouping factors, use the same A and H across all data
-    #         mu = A * (elapsed**n) / (H**n + elapsed**n)
-    #     # Consider the observations to be a sample with empirically known std dev,
-    #     # centered on the postulated latent true uptake.
-    #     if std_dev is None:
-    #         std_dev = 0.0000005
-    #     numpyro.sample(
-    #         "obs", dist.TruncatedNormal(mu, std_dev, low=0, high=1), obs=cum_uptake
-    #     )
 
     @staticmethod
     def augment_data(
@@ -991,11 +732,11 @@ class HillModel(UptakeModel):
         rollouts: List[dt.date] | None,
     ) -> CumulativeUptakeData:
         """
-        Format preprocessed data for fitting a Hill model.
+        Format preprocessed data for fitting a mixed Hill + Linear model.
 
         Parameters:
         data: CumulativeUptakeData
-            training data for fitting a Hill model
+            training data for fitting a mixed Hill + Linear model
          season_start_month: int
             first month of the overwinter disease season
         season_start_day: int
@@ -1006,7 +747,7 @@ class HillModel(UptakeModel):
             rollout dates for each season in the training data
 
         Returns:
-            Cumulative uptake data ready for fitting a Hill model.
+            Cumulative uptake data ready for fitting a mixed Hill + Linear model.
 
         Details
         The following steps are required to prepare preprocessed data
@@ -1035,7 +776,7 @@ class HillModel(UptakeModel):
         mcmc: dict,
     ) -> Self:
         """
-        Fit a hill model on training data.
+        Fit a mixed Hill + Linear model on training data.
 
         Parameters
         data: CumulativeUptakeData
@@ -1085,10 +826,7 @@ class HillModel(UptakeModel):
             self.value_to_index = None
 
         # Prepare the data to be fed to the model. Must be numpy arrays.
-        # Cannot have zero as a standard deviation.
         elapsed = data["elapsed"].to_numpy()
-        # cum_uptake = data["estimate"].to_numpy()
-        # std_dev = data["sdev"].to_numpy()
         N_vax = data["N_vax"].to_numpy()
         N_tot = data["N_tot"].to_numpy()
 
@@ -1103,8 +841,6 @@ class HillModel(UptakeModel):
         self.mcmc.run(
             self.rng_key,
             elapsed=elapsed,
-            # cum_uptake=cum_uptake,
-            # std_dev=std_dev,
             N_vax=N_vax,
             N_tot=N_tot,
             groups=group_codes,
@@ -1115,7 +851,6 @@ class HillModel(UptakeModel):
             A_sig=params["A_sig"],
             H_shape1=params["H_shape1"],
             H_shape2=params["H_shape2"],
-            # H_sig=params["H_sig"],
             n_shape=params["n_shape"],
             n_rate=params["n_rate"],
             M_shape=params["M_shape"],
@@ -1134,7 +869,7 @@ class HillModel(UptakeModel):
         scaffold: pl.DataFrame, season_start_month: int, season_start_day: int
     ) -> pl.DataFrame:
         """
-        Add columns to a scaffold of dates for forecasting from a Hill model.
+        Add columns to a scaffold of dates for forecasting from a mixed Hill + Linear model.
 
         Parameters:
         scaffold: pl.DataFrame
@@ -1145,18 +880,18 @@ class HillModel(UptakeModel):
             first day of the first month of the overwinter disease season
 
         Returns:
-            Scaffold with extra columns required by the Hill model.
+            Scaffold with extra columns required by the mixed Hill + Linear model.
 
         Details
         An extra column is added for the time elapsed since the season start.
-        That is all that's required to prepare the data for a Hill model.
+        Predictions are made as if 10,000 individuals are sampled.
         """
         scaffold = scaffold.with_columns(
             elapsed=iup.utils.date_to_elapsed(
                 pl.col("time_end"), season_start_month, season_start_day
             )
             / 365,
-            N_tot=pl.lit(1000),
+            N_tot=pl.lit(10000),
         ).drop("estimate")
 
         return scaffold
@@ -1172,7 +907,7 @@ class HillModel(UptakeModel):
         season_start_day: int,
     ) -> pl.DataFrame:
         """
-        Make projections from a fit hill model.
+        Make projections from a fit mixed Hill + Linear model.
 
         Parameters
         start_date: dt.date

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -44,14 +44,18 @@ models:
   - name: HillModel
     seed: 0
     params:
-      A_shape1: 60.0
-      A_shape2: 80.0
+      A_shape1: 100.0
+      A_shape2: 140.0
       A_sig: 40.0
-      H_shape1: 125.0
-      H_shape2: 300.0
-      H_sig: 40.0
+      H_shape1: 100.0
+      H_shape2: 225.0
       n_shape: 20.0
       n_rate: 5.0
+      M_shape: 1.0
+      M_rate: 0.1
+      M_sig: 40
+      S2_shape: 5.0
+      S2_rate: 0.5
     mcmc:
       num_warmup: 1000
       num_samples: 1000

--- a/scripts/model_demo.r
+++ b/scripts/model_demo.r
@@ -131,6 +131,19 @@ ggplot(
     xlab("Days Since Rollout") +
     ylab("Cumulative Uptake (%)")
 
+# TEMPORARY PLOT OF ALL DATA VS. A HILL FIT FROM NUMPYRO: A = 0.42, H = 0.32, N = 5.26
+data$elapsed_frac <- data$elapsed / 365
+d <- dplyr::select(data, -c(incident, interval, daily, previous, elapsed))
+m <- data.frame(elapsed_frac = 0:365 / 365)
+m$cumulative <- 0.42 * (m$elapsed_frac^5.26) / (0.32^5.26 + m$elapsed_frac^5.26)
+ggplot() +
+    geom_point(data = m, aes(x = elapsed_frac, y = 100 * cumulative)) +
+    geom_line(data = d, aes(x = elapsed_frac, y = 100 * cumulative, color = season)) +
+    theme_bw() +
+    theme(text = element_text(size = 15)) +
+    xlab("Fraction of Season") +
+    ylab("Cumulative Uptake (%)")
+
 # Tailor training data for LIM: drop first 2 dates per season & standardize
 train_lim <- train %>%
     group_by(season) %>%

--- a/scripts/model_demo.r
+++ b/scripts/model_demo.r
@@ -132,6 +132,18 @@ ggplot(
     xlab("Days Since Rollout") +
     ylab("Cumulative Uptake (%)")
 
+# TEMPORARY PLOT OF DATA BY STATE WITHIN A SEASON
+ggplot(
+    data = data[data$season == "2020/2021", ],
+    aes(x = elapsed_frac, y = 100 * cumulative, color = geography)
+) +
+    # geom_point() +
+    geom_line() +
+    theme_bw() +
+    theme(text = element_text(size = 15), legend.position = "none") +
+    xlab("Days Since Rollout") +
+    ylab("Cumulative Uptake (%)")
+
 # TEMPORARY PLOT OF ALL DATA VS. A HILL FIT FROM NUMPYRO: A = 0.42, H = 0.32, N = 5.26
 data$elapsed_frac <- data$elapsed / 365
 d <- dplyr::select(data, -c(incident, interval, daily, previous, elapsed))

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -29,15 +29,66 @@ def preprocess(
                 season_start_month=season_start_month,
                 season_start_day=season_start_day,
             ),
-            uci=pl.col("uci") - pl.col("estimate"),
-            lci=pl.col("estimate") - pl.col("lci"),
+            uci=pl.when(pl.col("uci") > pl.col("estimate"))
+            .then(pl.col("uci"))
+            .otherwise(pl.col("estimate") + 0.0000005),
+            lci=pl.when(pl.col("lci") < pl.col("estimate"))
+            .then(pl.col("lci"))
+            .otherwise(pl.col("estimate") - 0.0000005),
         )
-        .with_columns(sdev=pl.max_horizontal("uci", "lci") / st.norm.ppf(0.975, 0, 1))
-        .drop(["lci", "uci"])
         .with_columns(
-            sdev=pl.when(pl.col("sdev") < 0.0000005)
-            .then(0.0000005)
-            .otherwise(pl.col("sdev"))
+            estimate=pl.when(pl.col("estimate") > 0)
+            .then(pl.col("estimate"))
+            .otherwise(0.0005),
+            uci=pl.when(pl.col("estimate") > 0)
+            .then(pl.col("uci"))
+            .otherwise(pl.col("uci") + 0.0005),
+            lci=pl.when(pl.col("estimate") > 0)
+            .then(pl.col("lci"))
+            .otherwise(pl.col("lci") + 0.0005),
+        )
+        .with_columns(
+            uci_logodds=-(((1 / pl.col("uci")) - 1).log()),
+            lci_logodds=-(((1 / pl.col("lci")) - 1).log()),
+        )
+        .with_columns(logodds=(pl.col("uci_logodds") + pl.col("lci_logodds")) / 2)
+        .with_columns(p=(pl.col("logodds").exp()) / (1 + (pl.col("logodds").exp())))
+        .with_columns(
+            N=1
+            / (
+                pl.col("p")
+                * (1 - pl.col("p"))
+                * (
+                    (
+                        (pl.col("uci_logodds") - pl.col("logodds"))
+                        / st.norm.ppf(0.975, 0, 1)
+                    )
+                    ** 2
+                )
+            )
+        )
+        .with_columns(
+            sample_sig=(
+                (
+                    ((pl.col("p") ** 2) * (1 - pl.col("p")))
+                    + (((1 - pl.col("p")) ** 2) * pl.col("p"))
+                )
+                * pl.col("N")
+                / (pl.col("N") - 1)
+            ).sqrt()
+        )
+        .with_columns(sdev=pl.col("sample_sig") / (pl.col("N").sqrt()))
+        .drop(
+            [
+                "uci",
+                "lci",
+                "uci_logodds",
+                "lci_logodds",
+                "logodds",
+                "N",
+                "sample_sig",
+                "p",
+            ]
         )
     )
 

--- a/tests/test_hill_model.py
+++ b/tests/test_hill_model.py
@@ -23,9 +23,10 @@ def frame():
                 "2020-01-21",
                 "2020-01-21",
             ],
-            "estimate": [0.0, 0.0, 0.1, 0.01, 0.3, 0.03, 0.4, 0.04],
+            "N_vax": [1, 1, 100, 10, 300, 30, 400, 40],
+            "N_tot": [1000] * 8,
+            "estimate": [0.001, 0.001, 0.1, 0.01, 0.3, 0.03, 0.4, 0.04],
             "season": "2019/2020",
-            "sdev": [0.01] * 8,
         }
     ).with_columns(time_end=pl.col("time_end").str.strptime(pl.Date, "%Y-%m-%d"))
 
@@ -41,14 +42,18 @@ def params():
     """
 
     params = {
-        "A_shape1": 15.0,
-        "A_shape2": 20.0,
+        "A_shape1": 100.0,
+        "A_shape2": 140.0,
         "A_sig": 40.0,
-        "H_shape1": 25.0,
-        "H_shape2": 50.0,
-        "H_sig": 40.0,
+        "H_shape1": 100.0,
+        "H_shape2": 225.0,
         "n_shape": 20.0,
         "n_rate": 5.0,
+        "M_shape": 1.0,
+        "M_rate": 0.1,
+        "M_sig": 40,
+        "S2_shape": 5.0,
+        "S2_rate": 0.5,
     }
 
     return params


### PR DESCRIPTION
The Hill model is improved in two important ways:
- The observation-layer likelihood is now a beta-binomial, rather than a truncated Normal
- The true latent uptake is modeled by a Hill function _plus_ a linear function, rather than a Hill alone

This necessitates a change in preprocessing, by which each empirical point estimate and 95% confidence interval is translated into the total number of people surveyed and the (smaller) number of whom are vaccinated. To do this, we assume that the reported 95% CIs are Wald intervals on the standard error of the mean (SEM) for the point estimate. As such, the SEM is the half-width of the reported 95% CI divided by ~1.96. Letting $p = \text{point estimate of uptake}$, we solve the following for N:

```math
SEM = \sqrt{\frac{(1-p) \cdot p^2 + p \cdot (1-p)^2}{N}}
```

This allows us to calculate the total number of people surveyed, $N_{tot}$, and the number of people vaccinated, $N_{vax}$, for each data point.

The refactored Hill + Linear model fits the data much more easily: the MCMC chains move and produce posterior samples that are reasonable at first glance, even when grouping factors like season and state are included. There is likely more tinkering yet to be done (e.g. ESS is low for some parameters), but this will probably be easier dealt with once MCMC diagnostics and faceted forecast plots by grouping factor are built.

Please feel free to ignore `docs/model_journal.md` and `scripts/model_demo.R`! These are for my own record-keeping and sloppy scratchwork, respectively.