### PR TITLE
Refactor standardize utility

### DIFF
--- a/iup/utils.py
+++ b/iup/utils.py
@@ -22,6 +22,8 @@ def standardize(x, mn=None, sd=None):
 
     Details
     If the standard deviation is 0, all standardized values are 0.0.
+    If x is an np.ndarray, the mean and standard deviation should be provided,
+    not calculated, to prevent issues handling NaNs.
     """
     assert mn is not None or sd is not None and type(x) is np.ndarray, (
         "Calculating mean and std from a numpy array will not ignore NaNs!"

--- a/iup/utils.py
+++ b/iup/utils.py
@@ -23,20 +23,17 @@ def standardize(x, mn=None, sd=None):
     Details
     If the standard deviation is 0, all standardized values are 0.0.
     """
-    if type(x) is pl.Expr:
-        if mn is not None:
-            return (x - mn) / sd
-        else:
-            return (
-                pl.when(x.drop_nulls().n_unique() == 1)
-                .then(0.0)
-                .otherwise((x - x.mean()) / x.std())
-            )
+    assert mn is not None or sd is not None and type(x) is np.ndarray, (
+        "Calculating mean and std from a numpy array will not ignore NaNs!"
+    )
+
+    loc = mn if mn is not None else x.mean()
+    scale = sd if sd is not None else x.std(ddof=0)
+
+    if scale == 0.0:
+        return x * 0.0
     else:
-        if mn is not None:
-            return (x - mn) / sd
-        else:
-            return (x - x.mean()) / x.std()
+        return (x - loc) / scale
 
 
 def unstandardize(x, mn, sd):


### PR DESCRIPTION
The standardize utility is more compact, but still general to operate on polars expressions or numpy ndarrays, thanks to the serendipitously identical `.mean()` and `.std(ddof: int)` methods in polars and numpy. The only snag is that the polars versions conveniently ignore `nan`s while the numpy versions do not. Luckily, in this codebase, standardization of numpy ndarrays is always done with an externally provided mean and standard deviation, so the handling of `nan`s is a practical non-issue. Nonetheless an assert statement will catch our attention if this norm is ever broken, requiring further attention.

This will resolve #128 