### PR TITLE
More careful standardization

### DIFF
--- a/iup/utils.py
+++ b/iup/utils.py
@@ -30,13 +30,13 @@ def standardize(x, mn=None, sd=None):
             return (
                 pl.when(x.drop_nulls().n_unique() == 1)
                 .then(0.0)
-                .otherwise((x - x.mean()) / x.std())
+                .otherwise((x - x.mean()) / x.std(ddof=0))
             )
     else:
         if mn is not None:
             return (x - mn) / sd
         else:
-            return (x - x.mean()) / x.std()
+            return (x - x.nanmean()) / x.nanstd(ddof=0)
 
 
 def unstandardize(x, mn, sd):


### PR DESCRIPTION
The standardization utility now handles NaNs consistently and does not apply the Bessel correction, regardless of whether the input is a numpy ndarray or a polars expression. I tried to streamline the function to look cleaner, but lurking around every corner was some operation or conditional that required separating the ndarray vs. expression cases anyway. I don't think this is worth any more effort.

This will address #128 