### PR TITLE
Refactor of forecast.py script

### DIFF
--- a/iup/models.py
+++ b/iup/models.py
@@ -1070,7 +1070,6 @@ def build_scaffold(
     if test_dates is not None:
         scaffold = (
             test_dates.filter((pl.col("time_end").is_between(start_date, end_date)))
-            .select(["time_end", "season"])
             .with_columns(estimate=pl.lit(0.0))
             .unique()
         )

--- a/iup/models.py
+++ b/iup/models.py
@@ -68,7 +68,7 @@ class UptakeModel(abc.ABC):
         start_date: dt.date,
         end_date: dt.date,
         interval: str,
-        test_data: pl.DataFrame | None,
+        test_dates: pl.DataFrame | None,
         groups: List[str,] | None,
         season_start_month: int,
         season_start_day: int,

--- a/iup/models.py
+++ b/iup/models.py
@@ -533,7 +533,7 @@ class LinearIncidentUptakeModel(UptakeModel):
             the time interval between projection dates,
             following timedelta convention (e.g. '7d' = seven days)
         test_dates: pl.DataFrame | None
-            test data, if evaluation is being done, to provide exact dates
+            exact target dates to use, when test data exists
         group_cols: (str,) | None
             name(s) of the columns for the grouping factors
         season_start_month: int
@@ -919,7 +919,7 @@ class HillModel(UptakeModel):
             the time interval between projection dates,
             following timedelta convention (e.g. '7d' = seven days)
         test_dates: pl.DataFrame | None
-            test data, if evaluation is being done, to provide exact dates
+            exact target dates to use, when test data exists
         groups: (str,) | None
             name(s) of the columns for the grouping factors
         season_start_month: int
@@ -1049,7 +1049,7 @@ def build_scaffold(
         the time interval between projection dates,
         following timedelta convention (e.g. '7d' = seven days)
     test_dates pl.DataFrame | None
-        test data, if evaluation is being done, to provide exact dates
+        exact target dates to use, when test data exists
     group_combos: pl.DataFrame | None
         all unique combinations of grouping factors in the data
     season_start_month: int

--- a/iup/models.py
+++ b/iup/models.py
@@ -516,7 +516,7 @@ class LinearIncidentUptakeModel(UptakeModel):
         start_date: dt.date,
         end_date: dt.date,
         interval: str,
-        test_data: pl.DataFrame | None,
+        test_dates: pl.DataFrame | None,
         groups: List[str,] | None,
         season_start_month: int,
         season_start_day: int,
@@ -532,7 +532,7 @@ class LinearIncidentUptakeModel(UptakeModel):
         interval: str
             the time interval between projection dates,
             following timedelta convention (e.g. '7d' = seven days)
-        test_data: pl.DataFrame | None
+        test_dates: pl.DataFrame | None
             test data, if evaluation is being done, to provide exact dates
         group_cols: (str,) | None
             name(s) of the columns for the grouping factors
@@ -561,7 +561,7 @@ class LinearIncidentUptakeModel(UptakeModel):
             start_date,
             end_date,
             interval,
-            test_data,
+            test_dates,
             self.group_combos,
             season_start_month,
             season_start_day,
@@ -902,7 +902,7 @@ class HillModel(UptakeModel):
         start_date: dt.date,
         end_date: dt.date,
         interval: str,
-        test_data: pl.DataFrame | None,
+        test_dates: pl.DataFrame | None,
         groups: List[str,] | None,
         season_start_month: int,
         season_start_day: int,
@@ -918,7 +918,7 @@ class HillModel(UptakeModel):
         interval: str
             the time interval between projection dates,
             following timedelta convention (e.g. '7d' = seven days)
-        test_data: pl.DataFrame | None
+        test_dates: pl.DataFrame | None
             test data, if evaluation is being done, to provide exact dates
         groups: (str,) | None
             name(s) of the columns for the grouping factors
@@ -941,7 +941,7 @@ class HillModel(UptakeModel):
             start_date,
             end_date,
             interval,
-            test_data,
+            test_dates,
             self.group_combos,
             season_start_month,
             season_start_day,
@@ -1032,7 +1032,7 @@ def build_scaffold(
     start_date: dt.date,
     end_date: dt.date,
     interval: str,
-    test_data: pl.DataFrame | None,
+    test_dates: pl.DataFrame | None,
     group_combos: pl.DataFrame | None,
     season_start_month: int,
     season_start_day: int,
@@ -1048,7 +1048,7 @@ def build_scaffold(
     interval: str
         the time interval between projection dates,
         following timedelta convention (e.g. '7d' = seven days)
-    test_data: pl.DataFrame | None
+    test_dates pl.DataFrame | None
         test data, if evaluation is being done, to provide exact dates
     group_combos: pl.DataFrame | None
         all unique combinations of grouping factors in the data
@@ -1067,9 +1067,9 @@ def build_scaffold(
     """
     # If there is test data such that evaluation will be performed,
     # use exactly the dates that are in the test data
-    if test_data is not None:
+    if test_dates is not None:
         scaffold = (
-            test_data.filter((pl.col("time_end").is_between(start_date, end_date)))
+            test_dates.filter((pl.col("time_end").is_between(start_date, end_date)))
             .select(["time_end", "season"])
             .with_columns(estimate=pl.lit(0.0))
             .unique()

--- a/scripts/fit.py
+++ b/scripts/fit.py
@@ -74,7 +74,7 @@ def fit_model(
     """fit model using training data, return fitted model object"""
 
     """Run a single model for a single forecast date"""
-    train_data = iup.UptakeData.split_train_test(data, forecast_start, "train")
+    train_data, _ = iup.UptakeData.split_train_test(data, forecast_start)
 
     # Make an instance of the model, fit it using training data, and make projections
     fit_model = model_class(seed).fit(

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -47,7 +47,7 @@ def run_all_forecasts(
     all_forecast = pl.DataFrame()
 
     for model_name in model_names:
-        assert hasattr(iup.models.UptakeModel, model_name), (
+        assert hasattr(iup.models, model_name), (
             f"{model_name} is not a valid model type!"
         )
 
@@ -131,7 +131,7 @@ def run_forecast(
     if test_data.height == 0:
         test_dates = None
     else:
-        test_dates = test_data.select(pl.col("time_end"))
+        test_dates = test_data.select(["time_end", "season"])
 
     cumulative_projections = fit_model.predict(
         start_date=forecast_start,

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -1,7 +1,6 @@
 import argparse
-import datetime as dt
 import pickle
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import numpy as np
 import polars as pl
@@ -71,13 +70,20 @@ def run_all_forecasts(
 
             model = fitted_models[sel_key[0]]
 
-            forecast = run_forecast(
-                data=augmented_data,
-                fit_model=model,
-                grouping_factors=config["data"]["groups"],
-                forecast_start=forecast_date,
-                forecast_end=config["forecast_timeframe"]["end"],
-                forecast_interval=config["forecast_timeframe"]["interval"],
+            test_data = iup.UptakeData.split_train_test(
+                augmented_data, forecast_date, "test"
+            )
+            if test_data.height == 0:
+                test_dates = None
+            else:
+                test_dates = test_data.select(["time_end", "season"])
+
+            forecast = model.predict(
+                start_date=forecast_date,
+                end_date=config["forecast_timeframe"]["end"],
+                interval=config["forecast_timeframe"]["interval"],
+                test_dates=test_dates,
+                groups=config["data"]["groups"],
                 season_start_month=config["data"]["season_start_month"],
                 season_start_day=config["data"]["season_start_day"],
             )
@@ -91,59 +97,6 @@ def run_all_forecasts(
             all_forecast = pl.concat([all_forecast, forecast])
 
     return all_forecast
-
-
-def run_forecast(
-    data: iup.UptakeData,
-    grouping_factors: List[str] | None,
-    fit_model: iup.models.UptakeModel,
-    forecast_start: dt.date,
-    forecast_end: dt.date,
-    forecast_interval: str,
-    season_start_month: int,
-    season_start_day: int,
-) -> pl.DataFrame:
-    """
-    Given fitted model object, get forecast using predictors in test data.
-
-    Args:
-        data: iup.UptakeData
-            all available data including training and testing data.
-        grouping factors: List[str] | None
-            A list of column names to group "estimate" (dependent variable) in the data.
-        fit_model: iup.models.UptakeModel
-            A single iup.models.UptakeModel that is fitted.
-        forecast_start: dt.date
-            The first day of forecast.
-        forecast_end: dt.date
-            The last day of forecast.
-        season_start_month: int
-            The first month of an overwinter season.
-        season_start_day: int
-            The first day in the first month of an overwinter season.
-
-    Return:
-        A pl.DataFrame that records a predictive distribution at each time point
-        between forecast start and end from a fitted model.
-    """
-    # Get test data, if there is any, to know exact dates for projection
-    test_data = iup.UptakeData.split_train_test(data, forecast_start, "test")
-    if test_data.height == 0:
-        test_dates = None
-    else:
-        test_dates = test_data.select(["time_end", "season"])
-
-    cumulative_projections = fit_model.predict(
-        start_date=forecast_start,
-        end_date=forecast_end,
-        interval=forecast_interval,
-        test_dates=test_dates,
-        groups=grouping_factors,
-        season_start_month=season_start_month,
-        season_start_day=season_start_day,
-    )
-
-    return cumulative_projections
 
 
 if __name__ == "__main__":

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -2,7 +2,6 @@ import argparse
 import pickle
 from typing import Any, Dict
 
-import numpy as np
 import polars as pl
 import yaml
 
@@ -32,24 +31,16 @@ def run_all_forecasts(
         A pl.DataFrame saving predictive distribution at each time point between
         forecast start and end, at least grouped by model name, forecast start, and forecast end.
     """
+    all_forecasts = pl.DataFrame()
 
-    forecast_dates_list = [
-        parse_name_and_date(str)["forecast_date"] for str in fitted_models.keys()
-    ]
-    forecast_dates = np.array(forecast_dates_list)
-    forecast_dates = np.unique(forecast_dates)
-    forecast_dates.sort()
+    for model_details, fitted_model in fitted_models.items():
+        model_details = parse_name_and_date(model_details)
+        model_name = model_details["model_name"]
+        forecast_date = model_details["forecast_date"]
 
-    model_names = [
-        parse_name_and_date(str)["model_name"] for str in fitted_models.keys()
-    ]
-    all_forecast = pl.DataFrame()
-
-    for model_name in model_names:
         assert hasattr(iup.models, model_name), (
             f"{model_name} is not a valid model type!"
         )
-
         model_class = getattr(iup.models, model_name)
 
         augmented_data = model_class.augment_data(
@@ -60,43 +51,33 @@ def run_all_forecasts(
             config["data"]["rollouts"],
         )
 
-        for forecast_date in forecast_dates:
-            sel_key = [
-                key
-                for key in fitted_models
-                if parse_name_and_date(key)["forecast_date"] == forecast_date
-                if parse_name_and_date(key)["model_name"] == model_name
-            ]
+        test_data = iup.UptakeData.split_train_test(
+            augmented_data, forecast_date, "test"
+        )
+        if test_data.height == 0:
+            test_dates = None
+        else:
+            test_dates = test_data.select(["time_end", "season"])
 
-            model = fitted_models[sel_key[0]]
+        forecast = fitted_model.predict(
+            start_date=forecast_date,
+            end_date=config["forecast_timeframe"]["end"],
+            interval=config["forecast_timeframe"]["interval"],
+            test_dates=test_dates,
+            groups=config["data"]["groups"],
+            season_start_month=config["data"]["season_start_month"],
+            season_start_day=config["data"]["season_start_day"],
+        )
 
-            test_data = iup.UptakeData.split_train_test(
-                augmented_data, forecast_date, "test"
-            )
-            if test_data.height == 0:
-                test_dates = None
-            else:
-                test_dates = test_data.select(["time_end", "season"])
+        forecast = forecast.with_columns(
+            forecast_start=forecast_date,
+            forecast_end=config["forecast_timeframe"]["end"],
+            model=pl.lit(model_name),
+        )
 
-            forecast = model.predict(
-                start_date=forecast_date,
-                end_date=config["forecast_timeframe"]["end"],
-                interval=config["forecast_timeframe"]["interval"],
-                test_dates=test_dates,
-                groups=config["data"]["groups"],
-                season_start_month=config["data"]["season_start_month"],
-                season_start_day=config["data"]["season_start_day"],
-            )
+        all_forecasts = pl.concat([all_forecasts, forecast])
 
-            forecast = forecast.with_columns(
-                forecast_start=forecast_date,
-                forecast_end=config["forecast_timeframe"]["end"],
-                model=pl.lit(model_name),
-            )
-
-            all_forecast = pl.concat([all_forecast, forecast])
-
-    return all_forecast
+    return all_forecasts
 
 
 if __name__ == "__main__":

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -51,9 +51,7 @@ def run_all_forecasts(
             config["data"]["rollouts"],
         )
 
-        test_data = iup.UptakeData.split_train_test(
-            augmented_data, forecast_date, "test"
-        )
+        _, test_data = iup.UptakeData.split_train_test(augmented_data, forecast_date)
         if test_data.height == 0:
             test_dates = None
         else:

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -129,13 +129,15 @@ def run_forecast(
     # Get test data, if there is any, to know exact dates for projection
     test_data = iup.UptakeData.split_train_test(data, forecast_start, "test")
     if test_data.height == 0:
-        test_data = None
+        test_dates = None
+    else:
+        test_dates = test_data.select(pl.col("time_end"))
 
     cumulative_projections = fit_model.predict(
         start_date=forecast_start,
         end_date=forecast_end,
         interval=forecast_interval,
-        test_data=test_data,
+        test_dates=test_dates,
         groups=grouping_factors,
         season_start_month=season_start_month,
         season_start_day=season_start_day,

--- a/tests/test_uptake_data.py
+++ b/tests/test_uptake_data.py
@@ -39,15 +39,15 @@ def test_split_train_test(frame):
     Return the data in two halves
     """
     frame2 = frame.with_columns(time_end=pl.col("time_end") + pl.duration(days=365))
-    start_date = dt.date(2020, 6, 1)
+    split_date = dt.date(2020, 6, 1)
 
     output = iup.UptakeData.split_train_test(
-        iup.CumulativeUptakeData(pl.concat([frame, frame2])), start_date
+        iup.CumulativeUptakeData(pl.concat([frame, frame2])), split_date
     )
 
     assert output[0].equals(iup.CumulativeUptakeData(frame))
 
-    assert output[1].equals(iup.CumulativeUptakeData(pl.concat([frame, frame2])))
+    assert output[1].equals(iup.CumulativeUptakeData(frame2))
 
 
 def test_to_cumulative_handles_no_last(frame):

--- a/tests/test_uptake_data.py
+++ b/tests/test_uptake_data.py
@@ -34,32 +34,20 @@ def frame() -> iup.UptakeData:
     return iup.UptakeData(frame)
 
 
-def test_split_train_test_handles_train(frame):
+def test_split_train_test(frame):
     """
-    Return the training half of a data set.
-    """
-    frame2 = frame.with_columns(time_end=pl.col("time_end") + pl.duration(days=365))
-    start_date = dt.date(2020, 6, 1)
-
-    output = iup.UptakeData.split_train_test(
-        iup.CumulativeUptakeData(pl.concat([frame, frame2])), start_date, "train"
-    )
-
-    assert output.equals(iup.CumulativeUptakeData(frame))
-
-
-def test_split_train_test_handles_test(frame):
-    """
-    Return the testing half of a data set.
+    Return the data in two halves
     """
     frame2 = frame.with_columns(time_end=pl.col("time_end") + pl.duration(days=365))
     start_date = dt.date(2020, 6, 1)
 
     output = iup.UptakeData.split_train_test(
-        iup.CumulativeUptakeData(pl.concat([frame, frame2])), start_date, "test"
+        iup.CumulativeUptakeData(pl.concat([frame, frame2])), start_date
     )
 
-    assert output.equals(frame2)
+    assert output[0].equals(iup.CumulativeUptakeData(frame))
+
+    assert output[1].equals(iup.CumulativeUptakeData(pl.concat([frame, frame2])))
 
 
 def test_to_cumulative_handles_no_last(frame):


### PR DESCRIPTION
The `forecast.py` script is now much shorter and clearer, taking full advantage of the dictionary of fit models that @Fuhan-Yang created for us in #150. In the midst of this, #134 is addressed by trimming the test data down to dates and seasons _only_ before passing to `.predict()`.