### PR TITLE
Parallelized numpyro chains

### DIFF
--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -25,7 +25,7 @@ forecast_timeframe:
 # Details of the models to fit
 models:
   - name: LPLModel
-    seed: 0
+    seed: 1234
     params:
       A_shape1: 100.0
       A_shape2: 180.0

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -39,10 +39,12 @@ models:
       M_sig: 40
       d_shape: 350.0
       d_rate: 1.0
-    mcmc:
-      num_warmup: 1000
-      num_samples: 1000
-      num_chains: 1
+
+# MCMC control parameters
+mcmc:
+  num_warmup: 1000
+  num_samples: 1000
+  num_chains: 4
 
 # score metrics
 score_funs: [mspe, mean_bias, eos_abe]

--- a/scripts/fit.py
+++ b/scripts/fit.py
@@ -3,6 +3,7 @@ import datetime as dt
 import pickle as pkl
 from typing import Any, Dict, List, Type
 
+import numpyro
 import polars as pl
 import yaml
 
@@ -49,7 +50,7 @@ def fit_all_models(data, config) -> Dict[str, iup.models.UptakeModel]:
                 model_class=model_class,
                 seed=config_model["seed"],
                 params=config_model["params"],
-                mcmc=config_model["mcmc"],
+                mcmc=config["mcmc"],
                 grouping_factors=config["data"]["groups"],
                 forecast_start=forecast_date,
             )
@@ -96,6 +97,8 @@ if __name__ == "__main__":
         config = yaml.safe_load(f)
 
     input_data = iup.CumulativeUptakeData(pl.scan_parquet(args.input).collect())
+
+    numpyro.set_host_device_count(config["mcmc"]["num_chains"])
 
     all_models = fit_all_models(input_data, config)
 


### PR DESCRIPTION
If there are multiple MCMC chains for model fitting (and there should be), they now run in parallel. MCMC control parameters are now separated from model parameters in the config to set up the parallelization a little more easily.

This resolves issue #120. 

This also resolves issue #160, because that Arviz warning was basically saying that we should run more than 1 MCMC chain.

This also resolves issue #110, because I also split the random seed that initializes the model into two children: one for model fitting and one for prediction.