### PR TITLE
Update evaluation metrics for sample forecasts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,17 @@ SCORE_PLOTS = output/scores.png
 
 .PHONY: cache
 
-all: $(FORECASTS)
+all: $(RAW_DATA) $(MODEL_FITS) $(DIAGNOSTICS) $(FORECASTS) $(POSTERIORS) $(SCORES) $(PROJ_PLOTS) $(SUMMARY_PLOTS) $(SCORE_PLOTS)
 
 $(PROJ_PLOTS) $(SUMMARY_PLOTS): scripts/postprocess.py $(FORECASTS) $(RAW_DATA)
 	python $< \
 		--pred=$(FORECASTS) --obs=$(RAW_DATA) --config=$(CONFIG) \
 		--proj_output=$(PROJ_PLOTS) --summary_output=$(SUMMARY_PLOTS)
+
+$(SCORES): scripts/eval.py $(FORECASTS) $(RAW_DATA)
+	python $< \
+		--pred=$(FORECASTS) --obs=$(RAW_DATA) --config=$(CONFIG) \
+		--output=$(SCORES)
 
 $(FORECASTS): scripts/forecast.py $(RAW_DATA) $(MODEL_FITS) $(CONFIG)
 	python $< --input=$(RAW_DATA) --models=$(MODEL_FITS) --config=$(CONFIG) --output=$@

--- a/iup/eval.py
+++ b/iup/eval.py
@@ -97,6 +97,10 @@ def summarize_score(
     assert isinstance(data, CumulativeUptakeData)
     assert isinstance(pred, QuantileForecast)
 
+    assert len(pred["quantile"].unique()) == 1, (
+        "The prediction should only have one quantile."
+    )
+
     if groups is None:
         columns_to_join = ["time_end"]
     else:
@@ -109,7 +113,7 @@ def summarize_score(
     all_scores = pl.DataFrame()
     for score_name in score_funs:
         score = joined_df.select(
-            quantile=pl.col("quantile").unique().first(),
+            quantile=pl.col("quantile").first(),
             forecast_start=pl.col("time_end").min(),
             forecast_end=pl.col("time_end").max(),
             score_name=pl.lit(score_name),

--- a/iup/eval.py
+++ b/iup/eval.py
@@ -43,7 +43,7 @@ def check_date_match(
             for group_unique in data[group].unique()
         ]
     else:
-        assert data.shape[0] == pred.shape[0], (
+        assert (data["time_end"] == pred["time_end"]).all(), (
             "The forecast and the data should have the same forecast dates"
         )
 
@@ -63,7 +63,7 @@ def check_date_match(
         )
     else:
         assert not (any(data["time_end"].is_duplicated())), (
-            "Duplicated dates are found in data and prediction."
+            "Duplicated dates are found in data."
         )
 
 

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -62,7 +62,11 @@ models:
       num_chains: 1
 
 # score metrics
-score_funs: [mspe, mean_bias, eos_abe]
+# score metrics
+scores:
+  quantiles: [0.025,0.5,0.975] # Must specify at least one
+  difference_by_date: [2024-03-31] # if blank, abs_diff will not be used
+  others: mspe
 
 # Spacing between multiple forecasts, for evaluation
 evaluation_timeframe:

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -66,7 +66,7 @@ models:
 scores:
   quantiles: [0.025,0.5,0.975] # Must specify at least one
   difference_by_date: [2024-03-31] # if blank, abs_diff will not be used
-  others: mspe
+  others: [mspe]
 
 # Spacing between multiple forecasts, for evaluation
 evaluation_timeframe:

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -6,9 +6,11 @@ import yaml
 import iup
 from iup import eval
 
+from iup import SampleForecast
+
 
 def eval_all_forecasts(
-    data: pl.DataFrame, pred: pl.DataFrame, config: dict
+    data: pl.DataFrame, pred: SampleForecast, config: dict
 ) -> pl.DataFrame:
     """ "
     Calculates the evaluation metrics selected by config, by model and forecast start date.
@@ -17,12 +19,13 @@ def eval_all_forecasts(
     data:
         observed data with at least "time_end" and "estimate" columns
     pred:
-        forecast data as sample distribution with at least "time_end", "sample_id", "model", "forecast_start" and "estimate"
+        forecast data as sample distribution with at least "time_end", "sample_id", "model", "forecast_start" and "estimate",
+        should be a SampleForecast object
     config:
         config file to specify the expected quantile from the sample distribution and evaluation metrics to calculate
 
     Returns:
-        A pl.DataFrame with score name and score values, grouped by model, forecast start and quantile
+        A pl.DataFrame with score name and score values, grouped by model, forecast start, quantile, and possibly other grouping factors
     """
     model_names = pred["model"].unique()
     forecast_starts = pred["forecast_start"].unique()

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -4,9 +4,7 @@ import polars as pl
 import yaml
 
 import iup
-from iup import eval
-
-from iup import SampleForecast
+from iup import SampleForecast, eval
 
 
 def eval_all_forecasts(

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -7,47 +7,87 @@ import iup
 from iup import eval
 
 
-def eval_all_forecasts(data, pred, config):
-    """Evaluate the forecasts for all models, all forecast ends, and all scores"""
-    score_names = config["score_funs"]
+def eval_all_forecasts(
+    data: pl.DataFrame, pred: pl.DataFrame, config: dict
+) -> pl.DataFrame:
+    """ "
+    Calculates the evaluation metrics selected by config, by model and forecast start date.
+    -----------------------
+    Arguments:
+    data:
+        observed data with at least "time_end" and "estimate" columns
+    pred:
+        forecast data as sample distribution with at least "time_end", "sample_id", "model", "forecast_start" and "estimate"
+    config:
+        config file to specify the expected quantile from the sample distribution and evaluation metrics to calculate
+
+    Returns:
+        A pl.DataFrame with score name and score values, grouped by model, forecast start and quantile
+    """
     model_names = pred["model"].unique()
     forecast_starts = pred["forecast_start"].unique()
 
     all_scores = pl.DataFrame()
 
-    for score_name in score_names:
-        score_fun = getattr(eval, score_name)
-
-        for model in model_names:
-            for forecast_start in forecast_starts:
-                incident_pred = iup.PointForecast(
-                    iup.CumulativeUptakeData(
-                        pred.filter(
-                            pl.col("model") == model,
-                            pl.col("forecast_start") == forecast_start,
-                        )
-                    )
-                    .to_incident(config["data"]["groups"])
-                    .with_columns(quantile=0.5)
-                )
-
-                test = iup.CumulativeUptakeData(
-                    data.filter(
-                        pl.col("time_end") >= forecast_start,
-                        pl.col("time_end") <= config["forecast_timeframe"]["end"],
+    for model in model_names:
+        for forecast_start in forecast_starts:
+            incident_pred = iup.SampleForecast(
+                iup.CumulativeUptakeData(
+                    pred.filter(
+                        pl.col("model") == model,
+                        pl.col("forecast_start") == forecast_start,
                     )
                 ).to_incident(config["data"]["groups"])
+            )
+            test = iup.CumulativeUptakeData(
+                data.filter(
+                    pl.col("time_end") >= forecast_start,
+                    pl.col("time_end") <= config["forecast_timeframe"]["end"],
+                )
+            ).to_incident(config["data"]["groups"])
 
-                assert incident_pred.shape[0] == test.shape[0], (
+            # 1. Convert sample forecast pred into quantiles
+            assert config["scores"]["quantiles"] is not None, (
+                "Quantiles of posterior prediction distribution must be specified in the config file."
+            )
+            for quantile in config["scores"]["quantiles"]:
+                summary_pred = incident_pred.group_by("time_end").agg(
+                    pl.col("estimate").quantile(quantile)
+                )
+
+                assert summary_pred.shape[0] == test.shape[0], (
                     "The forecast and the test data do not have the same number of dates."
                 )
 
-                score = eval.score(test, incident_pred, score_fun).with_columns(
-                    score_fun=pl.lit(score_name),
-                    model=pl.lit(model),
+                # 2. Calculate the score for each quantile
+                score_df = test.join(
+                    summary_pred, on="time_end", how="inner", validate="1:1"
+                ).rename({"estimate": "data", "estimate_right": "pred"})
+
+                if config["scores"]["difference_by_date"] is not None:
+                    score_funcs = {
+                        f"{eval.abs_diff.__name__}_{date}": eval.abs_diff(
+                            date, pl.col("time_end")
+                        )
+                        for date in config["scores"]["difference_by_date"]
+                    }
+
+                score_funcs[config["scores"]["others"]] = getattr(
+                    eval, config["scores"]["others"]
                 )
 
-                all_scores = pl.concat([all_scores, score])
+                for score_name in score_funcs:
+                    score_fun = score_funcs[score_name]
+                    score = score_df.select(
+                        model=pl.lit(model),
+                        forecast_start=pl.col("time_end").min(),
+                        forecast_end=pl.col("time_end").max(),
+                        quantile=quantile,
+                        score_name=pl.lit(score_name),
+                        score_value=score_fun(pl.col("data"), pl.col("pred")),
+                    ).filter(pl.col("score_value").is_not_null())
+
+                    all_scores = pl.concat([all_scores, score])
 
     return all_scores
 
@@ -63,11 +103,8 @@ if __name__ == "__main__":
     with open(args.config) as f:
         config = yaml.safe_load(f)
 
-    pred = pl.scan_parquet(args.pred).collect()
-    data = pl.scan_parquet(args.obs).collect()
-
-    # Drop all samples and just use mean estimate, for now
-    pred = pred.drop([col for col in pred.columns if "estimate_" in col])
+    pred = pl.read_parquet(args.pred)
+    data = pl.read_parquet(args.obs)
 
     if config["evaluation_timeframe"]["interval"] is not None:
         eval_all_forecasts(data, pred, config).write_parquet(args.output)

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -78,9 +78,9 @@ def eval_all_forecasts(
                         for date in config["scores"]["difference_by_date"]
                     }
 
-                score_funcs[config["scores"]["others"]] = getattr(
-                    eval, config["scores"]["others"]
-                )
+                if config["scores"]["others"] is not None:
+                    for score_fun_name in config["scores"]["others"]:
+                        score_funcs[score_fun_name] = getattr(eval, score_fun_name)
 
                 scores = eval.summarize_score(
                     test, summary_pred, config["data"]["groups"], score_funcs

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -39,18 +39,34 @@ def pred():
     )
 
 
-def test_score_df(data, pred):
+@pytest.fixture
+def score_funs():
+    """
+    Mock of scoring functions.
+    """
+    return {
+        "mspe": eval.mspe,
+    }
+
+
+def test_summarize_score(
+    data,
+    pred,
+    score_funs,
+):
     """
     Return the expected forecast start, end and correct MSPE.
     """
     data = iup.IncidentUptakeData(data)
-    pred = iup.PointForecast(pred)
+    pred = iup.QuantileForecast(pred)
 
-    output = eval.point_score(data=data, pred=pred, score_fun=eval.mspe)
+    output = eval.summarize_score(data=data, pred=pred, score_funs=score_funs)
+
+    assert output.item(0, "quantile") == 0.5
     assert output.item(0, "forecast_start") == date(2020, 1, 1)
     assert output.item(0, "forecast_end") == date(2020, 1, 5)
-    # we're not testing the actual value, just that we get some value
-    assert isinstance(output["score"][0], float)
+    assert output.item(0, "score_name") == "mspe"
+    assert isinstance(output.item(0, "score_value"), float)
 
 
 def test_mspe():


### PR DESCRIPTION
- Updated iup.eval.py: 
1. Cleaned up previous metrics
2. Added a new function `abs_diff()` that returns a function to calculate absolute difference between predictions and observed data at specific date. 
3. Added a new function `summarize_score()` to loop through all score functions given observed data and predictions. Thanks for insights from @afmagee42 !

- Updated scripts/eval.py:

1. Converted prediction distribution into quantiles, allowing them to compare with observed data. 
2.  Get the functions that are returned by `abs_diff()`, and calculate together with `mspe()`. 

A long format of pl.DataFrame is returned, with `score_name` and `score_value`, grouped by `model`, `forecast_start` and `quantile`. Note that now model needs to be specified as `HillModel` to avoid the error (`lium` returns negative estimates), but this is fine as we will only use logistic + linear model. 
 
- Updated config.yaml: 
1. To enable users to select the date to calculate the difference for `abs_diff()`.
2. To specify which quantile from the prediction distribution to calculate the metrics

- Updated Makefile
- Updated test functions

Resolves #154 