### PR TITLE
Refactor plotting individual projections, summaries, and metrics

### DIFF
--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -45,7 +45,12 @@ models:
       num_chains: 1
 
 # score metrics
-score_funs: [mspe, mean_bias, eos_abe]
+# score metrics
+scores:
+  quantiles: [0.025,0.5,0.975] # Must specify at least one
+  difference_by_date: [2024-03-31] # if blank, abs_diff will not be used
+  others: mspe
+  group_to_plot: [season]
 
 # Spacing between multiple forecasts, for evaluation
 evaluation_timeframe:
@@ -53,9 +58,9 @@ evaluation_timeframe:
 
 # Prediction credible interval plot
 forecast_plots:
-  interval: # need to be a percentile #
-    lower: 2.5
-    upper: 97.5
+  interval: # need to be a fraction #
+    lower: 0.025
+    upper: 0.975
   n_trajectories: 20
 
 diagnostics:

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -47,9 +47,9 @@ models:
 # score metrics
 # score metrics
 scores:
-  quantiles: [0.025,0.5,0.975] # Must specify at least one
+  quantiles: [0.025,0.5,0.975] # Must specify at least one fraction
   difference_by_date: [2024-03-31] # if blank, abs_diff will not be used
-  others: mspe
+  others: [mspe]
   group_to_plot: [season]
 
 # Spacing between multiple forecasts, for evaluation

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -263,6 +263,7 @@ if __name__ == "__main__":
         config["data"]["groups"],
         config["forecast_plots"]["interval"]["lower"],
         config["forecast_plots"]["interval"]["upper"],
+        config["scores"]["group_to_plot"],
     ).save(args.summary_output)
 
-    plot_score(scores, config["score"]["group_to_plot"]).save(args.score_output)
+    plot_score(scores, config["scores"]["group_to_plot"]).save(args.score_output)

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -138,7 +138,7 @@ def plot_summary(
     plot_obs = obs.join(models_forecasts, how="cross").filter(
         pl.col("season").is_in(pred["season"].unique())
     )
-    
+
     plot_pred = pred.with_columns(
         lower=pl.col("estimate")
         .quantile(lci)

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -267,7 +267,6 @@ if __name__ == "__main__":
     with open(args.config, "r") as f:
         config = yaml.safe_load(f)
 
-    pred = pred.filter(pl.col("model") == pl.lit("HillModel"))
     plot_individual_projections(
         data,
         pred,


### PR DESCRIPTION
- Updated `plot_scores()` to plot the metrics along forecast start. Even though the metrics between the data and the 2.5% and 97.5% percentile of forecasts are calculated, only shows the metrics between the data and the median of forecasts.
- Added group to plot in `plot_scores()`,  `plot_summary()` and `plot_inidividual_projections()`. So far, only allow to plot one group factor, as it will be the column dimension besides the existing row dimension such as `forecast_start` or `metric type` in the 2D plot. 
- Added an option in `config_template.yaml` to allow to choose which group factor to plot. 

The plot showing the individual projections of forecasts: 
![image](https://github.com/user-attachments/assets/6275b557-b903-47f2-b283-3e1ca7667fb2)

The plot showing the mean and 95% prediction interval of forecasts:
![image](https://github.com/user-attachments/assets/38b38bcd-26d6-45ed-b6a2-3821fa3b4e1e)

The plot showing the evaluation metric changes over the forecast start date: 
![image](https://github.com/user-attachments/assets/62806c47-49a7-4ea3-a3fd-05cfaf134527)




