### PR TITLE
Adjusted Priors in Small but Crucial Ways

### DIFF
--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -29,16 +29,16 @@ models:
     params:
       A_shape1: 100.0
       A_shape2: 180.0
-      A_sig: 40.0
+      A_sig: 80.0
       H_shape1: 100.0
       H_shape2: 225.0
-      n_shape: 25.0
-      n_rate: 1.0
-      M_shape: 1.0
-      M_rate: 10.0
-      M_sig: 40
-      d_shape: 350.0
-      d_rate: 1.0
+      n_shape: 150.0
+      n_rate: 6.0
+      M_shape: 2.0
+      M_rate: 25.0
+      M_sig: 80.0
+      d_shape: 1000
+      d_rate: 3.0
 
 # MCMC control parameters
 mcmc:


### PR DESCRIPTION
I adjusted the suggested priors in the config template to give better MCMC behavior. The crucial change, I believe, is increasing the gamma prior for M (slope of the linear function) so that the prior probability approaches 0 as values of M approach 0. That is, while M is likely small, we are confident that it is also greater than 0.

Before making this change, 16 independent HMC chains across 4 different random seeds ranged in run times from 14 to 78 minutes, and the longer chains produced hundreds of divergences on rare occasions.

After this change, 20 independent HMC chains across 5 different random seeds ranged in run times from 10 to 13 minutes and produced at most 2 (but usually 0) divergences.

This is a tiny amount of code, but a big improvement. This addresses #171 