### PR TITLE
Excise parse_name_and_date

### DIFF
--- a/iup/utils.py
+++ b/iup/utils.py
@@ -1,5 +1,3 @@
-import datetime as dt
-import re
 from typing import List
 
 import numpy as np
@@ -161,21 +159,3 @@ def count_unique_values(array: np.ndarray) -> List[int,]:
         Number of unique values in each column of the array
     """
     return [len(np.unique(array[:, i])) for i in range(array.shape[1])]
-
-
-def parse_name_and_date(str) -> dict[str, dt.date]:
-    """
-    Parse a string to get the model name and forecast date
-
-    Args:
-        str: A string that has a pattern of "'Model name'_forecast_starts_'Forecast date'"
-
-    Return:
-        A dictionary of model name and forecast date.
-    """
-    pattern = re.compile("(.+)_forecast_starts_(.+)")
-    result = pattern.fullmatch(str).groups()
-    model_name = result[0]
-    date = dt.datetime.strptime(result[1], "%Y-%m-%d").date()
-
-    return {"model_name": model_name, "forecast_date": date}

--- a/scripts/diagnostics.py
+++ b/scripts/diagnostics.py
@@ -9,7 +9,6 @@ import yaml
 import iup
 import iup.diagnostics
 import iup.models
-from iup.utils import parse_name_and_date
 
 
 def diagnostic_plot(
@@ -29,7 +28,9 @@ def diagnostic_plot(
             plot_func = getattr(iup.diagnostics, plot_name)
             axes = plot_func(idata)
             fig = axes.ravel()[0].figure
-            fig.savefig(f"{output_dir}/{key}_{plot_name}.png")
+            fig.savefig(
+                f"{output_dir}/{key[0]}_forecast_start_{str(key[1])}_{plot_name}.png"
+            )
 
 
 def diagnostic_table(
@@ -52,7 +53,9 @@ def diagnostic_table(
             else:
                 output = table_func(idata)
 
-            output.write_parquet(f"{output_dir}/{key}_{table_name}.parquet")
+            output.write_parquet(
+                f"{output_dir}/{key[0]}_forecast_start_{str(key[1])}_{table_name}.parquet"
+            )
 
 
 def select_model_to_diagnose(models: Dict[str, iup.models.UptakeModel], config) -> dict:
@@ -82,8 +85,8 @@ def select_model_to_diagnose(models: Dict[str, iup.models.UptakeModel], config) 
     sel_keys = [
         key
         for key in models.keys()
-        if parse_name_and_date(key)["model_name"] in config["diagnostics"]["model"]
-        if parse_name_and_date(key)["forecast_date"] in forecast_dates
+        if key[0] in config["diagnostics"]["model"]
+        if key[1] in forecast_dates
     ]
 
     return {key: models[key] for key in sel_keys}

--- a/scripts/fit.py
+++ b/scripts/fit.py
@@ -55,7 +55,7 @@ def fit_all_models(data, config) -> Dict[str, iup.models.UptakeModel]:
                 forecast_start=forecast_date,
             )
 
-            label = f"{model_name}_forecast_starts_{forecast_date}"
+            label = (model_name, forecast_date)
             all_models[label] = fitted_model
 
     return all_models

--- a/scripts/forecast.py
+++ b/scripts/forecast.py
@@ -7,7 +7,6 @@ import yaml
 
 import iup
 import iup.models
-from iup.utils import parse_name_and_date
 
 
 def run_all_forecasts(
@@ -34,9 +33,8 @@ def run_all_forecasts(
     all_forecasts = pl.DataFrame()
 
     for model_details, fitted_model in fitted_models.items():
-        model_details = parse_name_and_date(model_details)
-        model_name = model_details["model_name"]
-        forecast_date = model_details["forecast_date"]
+        model_name = model_details[0]
+        forecast_date = model_details[1]
 
         assert hasattr(iup.models, model_name), (
             f"{model_name} is not a valid model type!"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 import polars as pl
 import pytest
 
@@ -61,16 +59,3 @@ def test_str():
     Provides a test string for test_parse_name_and_date().
     """
     return "HillModel_forecast_starts_2023-10-01"
-
-
-def test_parse_name_and_date(test_str):
-    """Parse a string in a certain pattern to get a dictionary of model name and forecast date."""
-
-    expected = {
-        "model_name": "HillModel",
-        "forecast_date": dt.date(2023, 10, 1),
-    }
-
-    result = iup.utils.parse_name_and_date(test_str)
-
-    assert result == expected


### PR DESCRIPTION
Per discussion in #166, it's more clear to represent the keys in model dictionary using tuple than string. Excise `parse_name_and_date()`.

Resolves #166 