### PR TITLE
Refactor streamlit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ SCORES = output/scores/$(RUN_ID)/
 all: $(SETTINGS) $(RAW_DATA) $(MODEL_FITS) $(DIAGNOSTICS) $(PREDICTIONS) $(SCORES)
 
 viz:
-	streamlit run scripts/viz.py
+	streamlit run scripts/viz.py -- \
+	--obs=$(RAW_DATA) --pred=$(PREDICTIONS) --score=$(SCORES) --config=$(CONFIG)
 
 $(SCORES): scripts/eval.py $(PREDICTIONS) $(RAW_DATA)
 	python $< \

--- a/scripts/viz.py
+++ b/scripts/viz.py
@@ -116,7 +116,14 @@ def plot_trajectories(obs: pl.DataFrame, pred: pl.DataFrame, config: Dict[str, A
 
     obs_chart = (
         alt.Chart(data)
-        .encode(x="time_end:T", y="observed:Q")
+        .encode(
+            x="time_end:T",
+            y="observed:Q",
+            tooltip=[
+                alt.Tooltip("time_end", title="Observation date"),
+                alt.Tooltip("observed", title="Observed uptake"),
+            ],
+        )
         .transform_calculate(type="'observed'")
         .mark_point()
         .encode(shape=alt.Shape("type:N", title="Type"))
@@ -124,7 +131,14 @@ def plot_trajectories(obs: pl.DataFrame, pred: pl.DataFrame, config: Dict[str, A
 
     pred_chart = (
         alt.Chart(data)
-        .encode(x="time_end:T", y="estimate:Q")
+        .encode(
+            x="time_end:T",
+            y="estimate:Q",
+            tooltip=[
+                alt.Tooltip("time_end", title="Observation date"),
+                alt.Tooltip("estimate", title="Predicted uptake"),
+            ],
+        )
         .transform_calculate(type="'predicted'")
         .mark_line()
         .encode(strokeDash=alt.StrokeDash("type:N", title=None))
@@ -227,7 +241,14 @@ def plot_summary(obs: pl.DataFrame, pred: pl.DataFrame, config: Dict[str, Any]):
 
     obs_chart = (
         alt.Chart(data)
-        .encode(x="time_end:T", y="estimate:Q")
+        .encode(
+            x="time_end:T",
+            y="estimate:Q",
+            tooltip=[
+                alt.Tooltip("time_end", title="Observation date"),
+                alt.Tooltip("estimate", title="Observed uptake"),
+            ],
+        )
         .transform_calculate(type="'observed'")
         .mark_point()
         .encode(shape=alt.Shape("type:N", title="Type"))
@@ -235,7 +256,14 @@ def plot_summary(obs: pl.DataFrame, pred: pl.DataFrame, config: Dict[str, Any]):
 
     pred_chart = (
         alt.Chart(data)
-        .encode(x="time_end:T", y="mean:Q")
+        .encode(
+            x="time_end:T",
+            y="mean:Q",
+            tooltip=[
+                alt.Tooltip("time_end", title="Observation date"),
+                alt.Tooltip("mean", title="Predicted mean"),
+            ],
+        )
         .transform_calculate(type="'predicted mean'")
         .mark_line()
         .encode(strokeDash=alt.StrokeDash("type:N", title=None))
@@ -251,6 +279,11 @@ def plot_summary(obs: pl.DataFrame, pred: pl.DataFrame, config: Dict[str, Any]):
             ),
             y="lower:Q",
             y2="upper:Q",
+            tooltip=[
+                alt.Tooltip("time_end", title="Observation date"),
+                alt.Tooltip("lower", title="Lower bound"),
+                alt.Tooltip("upper", title="Upper bound"),
+            ],
         )
     )
 
@@ -365,9 +398,8 @@ def layer_with_facets(charts: List, encodings: Dict):
     row_enc = encodings["row"]
     col_enc = encodings["column"]
     other_encs = {k: v for k, v in encodings.items() if k not in ["row", "column"]}
-    print(other_encs)
 
-    layered = alt.layer(*charts)
+    layered = alt.layer(*charts).interactive()
 
     layered = layered.encode(**other_encs)
 

--- a/scripts/viz.py
+++ b/scripts/viz.py
@@ -1,3 +1,5 @@
+import argparse
+from pathlib import Path
 from typing import Any, Dict, List
 
 import altair as alt
@@ -372,23 +374,27 @@ def layer_with_facets(charts: List, encodings: Dict):
     return layered.facet(row=row_enc, column=col_enc)
 
 
-@st.cache_data
-def load_data():
-    return {
-        "forecasts": pl.read_parquet("output/forecasts/tables/forecasts.parquet"),
-        "observed": pl.read_parquet("output/data/nis_raw_flu.parquet"),
-    }
-
-
-@st.cache_data
-def load_scores():
-    return pl.read_parquet("output/scores/test/scores.parquet")
-
-
-@st.cache_data
-def load_config():
-    return yaml.safe_load(open("scripts/config.yaml"))
-
-
 if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--obs", help="observed data")
+    p.add_argument("--pred", help="forecasts")
+    p.add_argument("--score", help="score metrics")
+    p.add_argument("--config", help="config yaml file")
+    args = p.parse_args()
+
+    @st.cache_data
+    def load_data():
+        return {
+            "observed": pl.read_parquet(Path(args.obs, "nis_data.parquet")),
+            "forecasts": pl.read_parquet(Path(args.pred, "forecasts.parquet")),
+        }
+
+    @st.cache_data
+    def load_scores():
+        return pl.read_parquet(Path(args.score, "scores.parquet"))
+
+    @st.cache_data
+    def load_config():
+        return yaml.safe_load(open(args.config, "r"))
+
     app()


### PR DESCRIPTION
- Debugged altair by having one single data source for multiple charts. 
Now if `make viz`, we should see trajectories of observed data along with other sample predictions; prediction interval (95% for now, can change in yaml) with mean trajectories and points from observed data; point plot of MSPE and absolute error of end-of-season uptake. 
- Integrated to the new Makefile structure. Connect streamlit as proposed in #195.
- Working on adding interaction: when mouse hovers on the plot, data will show up. 

Problems to solve: stop responding when plotting `geography` dimension, may be related to cache

Resolves #187 #190 