### PR TITLE
Clarify config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 #.idea/
 
 .vscode/
+
+scripts/config.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 RUN_ID = test
 TOKEN_PATH = scripts/socrata_app_token.txt
 TOKEN = $(shell cat $(TOKEN_PATH))
-CONFIG = scripts/config_template.yaml
+CONFIG = scripts/config.yaml
 SETTINGS = output/settings/$(RUN_ID)/
 RAW_DATA = output/data/$(RUN_ID)/
 MODEL_FITS = output/fits/$(RUN_ID)/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use <https://github.com/CDCgov/nis-py-api> for access to the NIS data.
 2. Installed the required dependencies with `poetry install`.
 3. Get a [Socrata app token](https://github.com/CDCgov/nis-py-api?tab=readme-ov-file#getting-started) and save it in `scripts/socrata_app_token.txt`.
 4. Cache NIS data with `make nis`.
-5. Copy the config template in `scripts/config_template.yaml` (e.g., to `scripts/config.yaml`) and fill in the necessary fields.
+5. Copy the config template in `scripts/config_template.yaml` to `scripts/config.yaml` and fill in the necessary fields.
     - data: specify the vaccination uptake data to use, including a de facto annual start of the disease season, filters for rows and columns to keep, and grouping factors by which to partition forecasts.
     - forecast_timeframe: specify the start and the end of the forecast period and the interval between reference dates in the forecast (using the [polars string language](https://docs.pola.rs/api/python/dev/reference/expressions/api/polars.date_range.html), e.g., `7d`).
     - evaluation_timeframe: specify the interval between forecast dates if multiple forecasts are desired (sharing the same end of the forecast period). This will create different forecast horizons, which can be compared with evaluation scores. If blank, no evaluation score will not be computed.

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -113,3 +113,5 @@ if __name__ == "__main__":
         eval_all_forecasts(data, pred, config).write_parquet(
             Path(args.output, "scores.parquet")
         )
+    else:
+        print("No evaluation timeframe specified, skipping evaluation.")


### PR DESCRIPTION
@eschrom Not sure if you had a different vision, but these were the changes I had to make in order for this repo to make sense to me.

Point Makefile to `scripts/config.yaml`, which is gitignore'd. In the README, tell users to copy `scripts/config_template.yaml` to this location and manipulate it. Add a note in `eval.py` that makes clear why evaluation isn't done, if it's not being done.