### PR TITLE
Use sample sizes in data

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -4,7 +4,6 @@ from typing import List
 
 import nisapi
 import polars as pl
-import scipy.stats as st
 import yaml
 
 import iup


### PR DESCRIPTION
We discovered that the NIS data has the sample size (i.e. number of phone calls) for each row in the data. The NIS-API now returns this as a column named `sample_size` which must be included, as enforced by validation. 

So now we can remove our back-calculation of the total sample size (`N_tot`) and number of respondents vaccinated (`N_vax`), and just use the reported `sample_size`.