### PR TITLE
Clarify uv virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use <https://github.com/CDCgov/nis-py-api> for access to the NIS data.
 
 ## Getting started
 
-1. Either set up a virtual environment and install all dependencies with `uv sync` and then enter the virtual environment with `.venv/Scripts/activate`, or else remember to prepend each of your command-line entries with `uv run` (e.g. `uv run make nis`).
+1. Either set up a virtual environment and install all dependencies with `uv sync` and then enter the virtual environment (with `.venv/Scripts/activate`, `.venv/bin/activate`, or similar), or else remember to prepend each of your command-line entries with `uv run` (e.g. `uv run make nis`).
 2. Get a [Socrata app token](https://github.com/CDCgov/nis-py-api?tab=readme-ov-file#getting-started) and save it in `scripts/socrata_app_token.txt`.
 3. Cache NIS data with `make nis`.
 4. Copy the config template in `scripts/config_template.yaml` to `scripts/config.yaml` and fill in the necessary fields.


### PR DESCRIPTION
In my last update to the README, I forgot to clarify that there may be different commands to enter a uv virtual environment. This depends on your operating system, which terminal you are using, whether you use custom venv names, etc., so it can differ from user to user. The README now clarifies that `.venv/bin/activate`, `.venv/Scripts/activate`, etc. are just examples of what the enter-my-virtual-environment command might be.