### PR TITLE
EDA on number of basis functions given cumulative and incidental uptake data

### DIFF
--- a/scripts/gam_k.R
+++ b/scripts/gam_k.R
@@ -1,0 +1,180 @@
+rm(list=ls())
+library(dplyr)
+library(ggplot2)
+library(mgcv)
+
+### national flu data ###
+
+##### data cleaning #####
+nis <- read.csv("data/nis_flu_national.csv")
+head(nis)
+nis$time_end = as.Date(nis$time_end)
+
+nis %>%
+  mutate(time_end=as.Date(time_end),
+         season_start_year= gsub("(\\d{4})/\\d{4}","\\1",season)) %>%
+  mutate(season_start=as.Date(paste0(season_start_year,"-07-01"))) %>%
+  mutate(elapsed=as.numeric(time_end-season_start))%>%
+  mutate(season=factor(season))%>%
+  group_by(season) %>%
+  mutate(inc=c(0,diff(estimate))) %>%
+  filter(inc !=0) %>%
+  select(-season_start_year) -> nis
+
+nis <- nis[order(nis$time_end),]
+
+train_end <- as.Date("2023-07-01")
+
+#### First 11 seasons as training, the rest 4 seasons as testing ###
+nis %>%
+  filter(time_end < train_end) -> nis_train
+
+nis %>%
+  filter(time_end >= train_end) -> nis_test
+
+##### model fitting ######
+# add log-normal link function by manually log-transforming response variable
+
+gam_k <- function(k) {
+  nis_gam <- gam(log(estimate) ~ s(elapsed,bs="bs",k=k) + s(season,bs="re"),data= nis_train)
+
+  return(nis_gam)
+}
+
+get_pred_k <- function(k) {
+  nis_gam <- gam(log(estimate) ~ s(elapsed,bs="bs",k=k) + s(season,bs="re"),data= nis_train)
+
+  ### Prediction ###
+  pred_values <- predict(nis_gam, newdata=nis_test,types="response")
+  nis_test$pred_terms <- exp(pred_values)
+
+  return(nis_test)
+}
+
+mspe <- function(data, pred) {
+  mean((data-pred)^2)
+}
+
+### get model ###
+gam_list <- lapply(5:15,function(x) {gam_k(x)})
+
+lapply(1:length(gam_list),function(x) {gam_list[[x]]$aic})
+lapply(1:length(gam_list),function(x) {gam_list[[x]]$edf})
+
+fitted_k <- lapply(1:length(gam_list),function(x) {
+  nis_train$fitted = exp(gam_list[[x]]$fitted.values)
+                   return(nis_train)})
+
+names(fitted_k) <- paste0("k=",c(5:15))
+
+fitted_k_df <- plyr::ldply(fitted_k)
+
+fitted_k_df %>%
+  mutate(.id=factor(.id,levels=paste0("k=",c(5:15)))) %>%
+  ggplot() +
+  geom_point(aes(x=elapsed,y=estimate)) +
+  geom_line(aes(x=elapsed,y=fitted,color=season)) +
+  facet_wrap(.id~.) +
+  theme_bw()
+ggsave("plot/gam_k_cumu_fitted.jpg",width=10,height=6)
+
+pred_k <- lapply(5:15, function(x) {get_pred_k(x)})
+names(pred_k) = paste0("k=",c(5:15))
+
+pred_k_df <- plyr::ldply(pred_k)
+
+pred_k_df %>%
+  mutate(.id=factor(.id,levels=paste0("k=",c(5:15)))) %>%
+  ggplot() +
+  geom_point(aes(x=elapsed,y=estimate)) +
+  geom_line(aes(x=elapsed,y=pred_terms)) +
+  facet_wrap(.id~.) +
+  theme_bw()
+ggsave("plot/gam_k_cumu_pred.jpg",width=10,height=6)
+
+pred_k_df %>%
+  group_by(.id) %>%
+  reframe(mspe=mspe(estimate,pred_terms)) %>%
+  mutate(id=factor(.id,levels=paste0("k=",c(5:15)))) -> mspe_cum
+
+mspe_cum %>%
+  ggplot() +
+  geom_col(aes(x=id,y=mspe)) +
+  theme_bw()
+ggsave("plot/mspe_cum_gam_k.jpg",width=6,height=4)
+
+############# try on incident data ###########
+gam_inc_k <- function(k){
+  nis_gam <- gam(log(inc) ~ s(elapsed,bs="bs",k=k) + s(season,bs="re"),data= nis_train)
+
+  return(nis_gam)
+}
+
+get_pred_inc_k <- function(k) {
+
+  nis_gam <- gam(log(inc) ~ s(elapsed,bs="bs",k=k) + s(season,bs="re"),data= nis_train)
+
+  ### Prediction ###
+  pred_values <- predict(nis_gam, newdata=nis_test,types="response")
+  nis_test$pred_terms <- exp(pred_values)
+
+  return(nis_test)
+}
+
+### get model ###
+gam_list <- lapply(5:15,function(x) {gam_inc_k(x)})
+
+lapply(1:length(gam_list),function(x) {gam_list[[x]]$aic})
+lapply(1:length(gam_list),function(x) {gam_list[[x]]$edf})
+
+fitted_k <- lapply(1:length(gam_list),function(x) {
+  nis_train$fitted = exp(gam_list[[x]]$fitted.values)
+  return(nis_train)})
+
+names(fitted_k) <- paste0("k=",c(5:15))
+
+fitted_k_df <- plyr::ldply(fitted_k)
+
+fitted_k_df %>%
+  mutate(.id=factor(.id,levels=paste0("k=",c(5:15)))) %>%
+  ggplot() +
+  geom_point(aes(x=elapsed,y=inc)) +
+  geom_line(aes(x=elapsed,y=fitted,color=season)) +
+  facet_wrap(.id~.) +
+  theme_bw()
+ggsave("plot/gam_k_cumu_fitted.jpg",width=10,height=6)
+
+pred_k <- lapply(5:15, function(x) {get_pred_inc_k(x)})
+names(pred_k) = paste0("k=",c(5:15))
+
+pred_k_df <- plyr::ldply(pred_k)
+
+pred_k_df %>%
+  mutate(.id=factor(.id,levels=paste0("k=",c(5:15)))) %>%
+  ggplot() +
+  geom_point(aes(x=elapsed,y=inc)) +
+  geom_line(aes(x=elapsed,y=pred_terms)) +
+  facet_wrap(.id~.) +
+  theme_bw()
+ggsave("plot/gam_k_cumu_pred.jpg",width=10,height=6)
+
+pred_k_df %>%
+  group_by(.id) %>%
+  reframe(mspe=mspe(inc,pred_terms)) %>%
+  mutate(id=factor(.id,levels=paste0("k=",c(5:15)))) -> mspe_inc
+
+mspe_inc %>%
+  ggplot() +
+  geom_col(aes(x=id,y=mspe)) +
+  theme_bw()
+ggsave("plot/mspe_inc_gam_k.jpg",width=6,height=4)
+
+mspe_inc %>%
+  mutate(type="incidental") %>%
+  bind_rows(mspe_cum %>%
+              mutate(type="cumulative")) %>%
+  ggplot() +
+  geom_col(aes(x=id,y=mspe)) +
+  facet_wrap(type~.) +
+  theme_bw()
+ggsave("plot/all_mspe_gam_k.jpg",width=8,height=6)


### PR DESCRIPTION
Before switching to Bayesian framework, I did a quick EDA based on today's discussion: how does gam perform given different number of basis functions on cumulative and incidental data?

Conditions: 
1. Flu vaccine uptake data from NIS is used.  
2. Model is assumed to be log-normal distributed (log link function)
3. Cubic basis spline function is used
4. Incidence data is calculated as the difference of cumulative data, and the first "0" point is trimmed to ensure all the data is eligible for log link function.
5. Training and test data is split on 2023-07-01. Season 2023/2024 is used for test. 

Methods:
1. GAM model is fitted given the number of basis functions (k) varied between 5 and 15. 
2. Fitted values and predictions are plotted for each k.
3. MSPE is calculated between test data and prediction for each k. 

Results: 
![gam_k_cumu_fitted](https://github.com/user-attachments/assets/4d3b685e-d44a-4f21-a454-d2a95d1350d8)
As we found out in the morning that more basis functions are needed to better fit the smooth shape of the cumulative data, this also applies to prediction:
![gam_k_cumu_pred](https://github.com/user-attachments/assets/424d7796-3b3e-4d92-8382-6cd9c5b1ccf9)
k needs to be at least 10 to fit and predict the smooth sigmoid shape of the cumulative data. 

Thus, followed by the thought that incidental data may need fewer basis functions as it includes the turning shape by itself, we've used the same method on incidental data: 
![gam_k_inc_fitted](https://github.com/user-attachments/assets/1a21b6a9-3afd-4fd0-9bf3-cac8adf28537)
Interestingly, it is found that k is needed to be at least 8 to fit the peak of the incidental vaccine uptake. I speculate that more basis function still provides higher flexibility to model the sharp turning (peak) of the incidence data.

This also applies to prediction: 
![gam_k_inc_pred](https://github.com/user-attachments/assets/452bf277-53a5-4799-91bd-454301102bbd)

But the peak can be fitted and predicted when k is at least 8, which is lower than the k for cumulative data. Thus, our assumption is valid that it is easier to capture the wiggliness of the incidence data than cumulative data. 

Also confirmed this using MSPE between test and prediction across k for incidence and cumulative data:
![all_mspe_gam_k](https://github.com/user-attachments/assets/f58b093c-08d2-4c13-867e-96037199d4de)

We can see that incidence data has pronounced advantage in predicting vaccine uptake. Given the results, I will move forward with trying incidence data on the Bayesian framework, first. 

I also searched if there is basis function that is similar to sigmoid function, but because the basis functions are naturally polynomials, there is no basis function that has sigmoid shape. Increasing k to achieve the sigmoid shape of the smooth function is the common approach, as we expected. This also supports us to move forward with incidence data. 