### PR TITLE
Call it "forecast date"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ SCORES = $(OUTPUT_DIR)/scores.parquet
 PLOT_DATA = $(OUTPUT_DIR)/plots/data_one_season_by_state.png
 PLOT_PREDS = $(OUTPUT_DIR)/plots/forecast_example.png
 
-FORECAST_STARTS = $(shell python scripts/get_forecast_starts.py --config=$(CONFIG))
-PREDS = $(foreach date,$(FORECAST_STARTS),$(PRED_DIR)/forecast_start=$(date)/part-0.parquet)
-FITS = $(foreach date,$(FORECAST_STARTS),$(OUTPUT_DIR)/fits/fit_$(date).pkl)
+FORECAST_DATES = $(shell python scripts/get_forecast_dates.py --config=$(CONFIG))
+PREDS = $(foreach date,$(FORECAST_DATES),$(PRED_DIR)/forecast_date=$(date)/part-0.parquet)
+FITS = $(foreach date,$(FORECAST_DATES),$(OUTPUT_DIR)/fits/fit_$(date).pkl)
 
 # This variable because the pattern `forecast_date=2020-01-01` confuses make.
 # It thinks `=%` is variable assignment, not pattern matching.
@@ -45,12 +45,12 @@ $(PLOT_DATA): scripts/plot_data.py $(DATA) $(CONFIG)
 $(PREDS_FLAG): $(PREDS)
 	touch $@
 
-# output/run_id/pred/forecast_start=2021-01-01/part-0.parquet <== output/fits/fit_2021-01-01.pkl
-$(PRED_DIR)/forecast_start$(EQ)%/part-0.parquet: scripts/predict.py $(OUTPUT_DIR)/fits/fit_%.pkl $(DATA) $(CONFIG)
+# output/run_id/pred/forecast_date=2021-01-01/part-0.parquet <== output/fits/fit_2021-01-01.pkl
+$(PRED_DIR)/forecast_date$(EQ)%/part-0.parquet: scripts/predict.py $(OUTPUT_DIR)/fits/fit_%.pkl $(DATA) $(CONFIG)
 	python $< --data=$(DATA) --fits=$(OUTPUT_DIR)/fits/fit_$*.pkl --config=$(CONFIG) --output=$@
 
 $(OUTPUT_DIR)/fits/fit_%.pkl: scripts/fit.py $(DATA) $(CONFIG)
-	python $< --data=$(DATA) --forecast_start=$* --config=$(CONFIG) --output=$@
+	python $< --data=$(DATA) --forecast_date=$* --config=$(CONFIG) --output=$@
 
 $(DATA): scripts/preprocess.py $(RAW_DATA) $(CONFIG)
 	python $< --config=$(CONFIG) --input=$(RAW_DATA) --output=$@

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can modify `config.yaml` or point to a new config file to produce different 
 flowchart TB;
 
 data[output/RUN_ID/data.parquet];
-pred[output/RUN_ID/pred/forecast_start=DATE/part-0.parquet];
+pred[output/RUN_ID/pred/forecast_date=DATE/part-0.parquet];
 scores[output/RUN_ID/scores.parquet];
 preprocess[/scripts/preprocess.py/];
 fit[/scripts/fit.py/];

--- a/iup/eval.py
+++ b/iup/eval.py
@@ -7,11 +7,11 @@ def mspe(
     obs: pl.DataFrame, pred: pl.DataFrame, grouping_factors: List[str]
 ) -> pl.DataFrame:
     return (
-        pred.group_by(["model", "time_end", "forecast_start"] + grouping_factors)
+        pred.group_by(["model", "time_end", "forecast_date"] + grouping_factors)
         .agg(pred_median=pl.col("estimate").median())
         .join(obs, on=["time_end"] + grouping_factors, how="right")
         .with_columns(score_value=(pl.col("estimate") - pl.col("pred_median")) ** 2)
-        .group_by(["model", "forecast_start"] + grouping_factors)
+        .group_by(["model", "forecast_date"] + grouping_factors)
         .agg(pl.col("score_value").mean())
         .with_columns(score_fun=pl.lit("mspe"))
     )
@@ -36,7 +36,7 @@ def eos_abs_diff(
     assert "season" in grouping_factors
 
     median_pred = pred.group_by(
-        ["model", "time_end", "forecast_start"] + grouping_factors
+        ["model", "time_end", "forecast_date"] + grouping_factors
     ).agg(pred_median=pl.col("estimate").median())
 
     return (

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -39,7 +39,7 @@ mcmc:
   num_chains: 4
   progress_bar: false
 
-forecast_starts:
+forecast_dates:
   start: 2021-09-01
   end: 2021-11-01
   interval: 1mo
@@ -52,7 +52,7 @@ forecast_plots:
 
 # diagnostics are not produced by default
 diagnostics:
-  forecast_starts: [2021-07-01]
+  forecast_dates: [2021-07-01]
   models: [LPLModel]
   plots: [posterior_density_plot, parameter_trace_plot]
   tables: [print_posterior_dist, print_model_summary]

--- a/scripts/diagnostics.py
+++ b/scripts/diagnostics.py
@@ -39,13 +39,13 @@ if __name__ == "__main__":
     with open(args.config, "r") as f:
         config = yaml.safe_load(f)
 
-    for key in ["forecast_starts", "models", "tables", "plots"]:
+    for key in ["forecast_dates", "models", "tables", "plots"]:
         assert isinstance(config["diagnostics"][key], list), (
             f"config['diagnostics']['{key}'] should be a list"
         )
 
-    for forecast_start in config["diagnostics"]["forecast_starts"]:
-        fc_date = dt.date.fromisoformat(forecast_start)
+    for forecast_date in config["diagnostics"]["forecast_dates"]:
+        fc_date = dt.date.fromisoformat(forecast_date)
 
         for model in config["diagnostics"]["models"]:
             with open(Path(args.fits_dir) / f"fit_{fc_date}.pkl", "rb") as f:
@@ -59,7 +59,7 @@ if __name__ == "__main__":
                     fit=fit,
                     output_path=Path(
                         args.output_dir,
-                        f"model={model}_forecast_start={fc_date}_{table}.csv",
+                        f"model={model}_forecast_date={fc_date}_{table}.csv",
                     ),
                 )
 
@@ -69,6 +69,6 @@ if __name__ == "__main__":
                     fit=fit,
                     output_path=Path(
                         args.output_dir,
-                        f"model={model}_forecast_start={fc_date}_{plot}.png",
+                        f"model={model}_forecast_date={fc_date}_{plot}.png",
                     ),
                 )

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -16,14 +16,14 @@ def eval_all_forecasts(
     data:
         observed data with at least "time_end" and "estimate" columns
     pred:
-        forecast data as sample distribution with at least "time_end", "sample_id", "model", "forecast_start" and "estimate",
+        forecast data as sample distribution with at least "time_end", "sample_id", "model", "forecast_date" and "estimate",
     config:
         config file to specify the expected quantile from the sample distribution and evaluation metrics to calculate
 
     Returns:
         A pl.DataFrame with score name and score values, grouped by model, forecast start, quantile, and possibly other grouping factors
     """
-    forecast_starts = pred["forecast_start"].unique()
+    forecast_dates = pred["forecast_date"].unique()
 
     assert "score_funs" in config, (
         f"`score_funs` not among config keys: {config.keys()}"
@@ -33,7 +33,7 @@ def eval_all_forecasts(
     assert config["groups"] is not None
     cols = config["groups"] + [
         "model",
-        "forecast_start",
+        "forecast_date",
         "score_value",
         "score_fun",
         "score_type",
@@ -41,13 +41,13 @@ def eval_all_forecasts(
 
     all_scores = pl.DataFrame()
 
-    for forecast_start in forecast_starts:
+    for forecast_date in forecast_dates:
         # get a fit score
-        fit_data = data.filter(pl.col("time_end") <= forecast_start)
-        fit_pred = pred.filter(pl.col("time_end") <= forecast_start)
+        fit_data = data.filter(pl.col("time_end") <= forecast_date)
+        fit_pred = pred.filter(pl.col("time_end") <= forecast_date)
 
-        fc_data = data.filter(pl.col("time_end") > forecast_start)
-        fc_pred = pred.filter(pl.col("time_end") > forecast_start)
+        fc_data = data.filter(pl.col("time_end") > forecast_date)
+        fc_pred = pred.filter(pl.col("time_end") > forecast_date)
 
         for score_fun in score_funs:
             fit_scores = (

--- a/scripts/figs_panels.py
+++ b/scripts/figs_panels.py
@@ -79,7 +79,7 @@ def load_data(path):
 
 
 def load_pred(path, data):
-    pred = pl.read_parquet(path).drop(["forecast_start", "forecast_end", "model"])
+    pred = pl.read_parquet(path).drop(["forecast_date", "forecast_end", "model"])
     return (
         pred.group_by(["time_end", "geography", "season"])
         .agg(
@@ -222,7 +222,7 @@ def plot_uptake(data, color="green", season_start_month=7, upper_bound=0.6):
         alt.layer(*plot_list).facet("geography", columns=9).configure_header(
             labelFontSize=40
         ).configure_axis(labelFontSize=30, titleFontSize=30).display()
-    elif "forecast_start" in data.columns:
+    elif "forecast_date" in data.columns:
         alt.layer(*plot_list).facet("forecast_start", columns=4).configure_header(
             labelFontSize=40
         ).configure_axis(labelFontSize=30, titleFontSize=30).display()

--- a/scripts/get_forecast_dates.py
+++ b/scripts/get_forecast_dates.py
@@ -11,11 +11,11 @@ if __name__ == "__main__":
     with open(args.config) as f:
         config = yaml.safe_load(f)
 
-    forecast_starts = pl.date_range(
-        config["forecast_starts"]["start"],
-        config["forecast_starts"]["end"],
-        config["forecast_starts"]["interval"],
+    forecast_dates = pl.date_range(
+        config["forecast_dates"]["start"],
+        config["forecast_dates"]["end"],
+        config["forecast_dates"]["interval"],
         eager=True,
     )
 
-    print(*forecast_starts, sep=" ")
+    print(*forecast_dates, sep=" ")

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -56,7 +56,7 @@ def run_all_forecasts(
             groups=config["groups"],
             season_start_month=config["season"]["start_month"],
             season_start_day=config["season"]["start_day"],
-        ).with_columns(forecast_start=forecast_date, model=pl.lit(model_name))
+        ).with_columns(forecast_date=forecast_date, model=pl.lit(model_name))
 
         all_forecasts = pl.concat([all_forecasts, forecast])
 

--- a/scripts/viz.py
+++ b/scripts/viz.py
@@ -109,9 +109,9 @@ def plot_trajectories(obs: pl.DataFrame, preds_path: str, config: Dict[str, Any]
     pred = sample_preds(preds_path, n_samples=n_samples)
 
     st.subheader("Data channels")
-    dimensions = ["model", "forecast_start"] + config["groups"]
+    dimensions = ["model", "forecast_date"] + config["groups"]
     default_channels = {
-        "column": ("Column", "forecast_start"),
+        "column": ("Column", "forecast_date"),
         "row": ("Row", "model"),
     }
 
@@ -142,13 +142,13 @@ def plot_trajectories(obs: pl.DataFrame, preds_path: str, config: Dict[str, Any]
         pred = pred.filter(pl.col(dim) == pl.lit(filter_val))
 
     # merge observed data with prediction by the combination of models and forecast starts
-    model_forecast_starts = pred.select(["model", "forecast_start"]).unique()
-    plot_obs = obs.join(model_forecast_starts, how="cross").filter(
+    model_forecast_dates = pred.select(["model", "forecast_date"]).unique()
+    plot_obs = obs.join(model_forecast_dates, how="cross").filter(
         pl.col(factor).is_in(pred[factor].unique().implode())
         for factor in config["groups"]
     )
 
-    groupings = ["model", "forecast_start", "time_end"] + config["groups"]
+    groupings = ["model", "forecast_date", "time_end"] + config["groups"]
 
     data = pred.join(plot_obs, on=groupings).rename({"estimate_right": "observed"})
 
@@ -201,7 +201,7 @@ def plot_summary(obs: pl.DataFrame, preds_path: str, config: Dict[str, Any]):
         The configuration yaml file.
     """
     # summarize sample predictions by grouping factors
-    groups_to_include = ["model", "forecast_start", "time_end"] + config["groups"]
+    groups_to_include = ["model", "forecast_date", "time_end"] + config["groups"]
     pred = summarize_preds(
         path=preds_path,
         groups_to_include=tuple(groups_to_include),
@@ -211,8 +211,8 @@ def plot_summary(obs: pl.DataFrame, preds_path: str, config: Dict[str, Any]):
     encodings = {}
 
     # data process: merge observed data with prediction by combinations of model and forecast start #
-    forecast_starts = pred.select(["model", "forecast_start"]).unique()
-    plot_obs = obs.join(forecast_starts, how="cross").filter(
+    forecast_dates = pred.select(["model", "forecast_date"]).unique()
+    plot_obs = obs.join(forecast_dates, how="cross").filter(
         pl.col(factor).is_in(pred[factor].unique().implode())
         for factor in config["groups"]
     )
@@ -222,18 +222,18 @@ def plot_summary(obs: pl.DataFrame, preds_path: str, config: Dict[str, Any]):
     # select which data dimension to put into which plot channel
     st.header("Plot options")
     st.subheader("Data channels")
-    dimensions = ["model", "forecast_start"] + config["groups"]
+    dimensions = ["model", "forecast_date"] + config["groups"]
 
     if "season" in dimensions:
         default_channels = {
             "color": ("Color", "model"),
-            "column": ("Column", "forecast_start"),
+            "column": ("Column", "forecast_date"),
             "row": ("Row", "season"),
         }
     else:
         default_channels = {
             "color": ("Color", "model"),
-            "column": ("Column", "forecast_start"),
+            "column": ("Column", "forecast_date"),
             "row": ("Row", "None"),
         }
 
@@ -332,7 +332,7 @@ def plot_evaluation(scores: pl.DataFrame, config: Dict[str, Any]):
     """
 
     encodings = {
-        "x": alt.X("forecast_start:T", title="Forecast start date"),
+        "x": alt.X("forecast_date:T", title="Forecast start date"),
         "y": alt.Y("score_value:Q", title="Score value"),
     }
 


### PR DESCRIPTION
- Throughout, refer to the "forecast date." The data available for training models is everything up through the forecast date.
- Remove the concept of a "forecast end," which is no longer used in the pipeline, which instead makes predictions for all observed dates (i.e., model fits from up through the forecast date, and then forecasts thereafter)
- Simplify the forecast dates in the config