### PR TITLE
Simplify the score plots

### DIFF
--- a/iup/utils.py
+++ b/iup/utils.py
@@ -5,7 +5,7 @@ import polars as pl
 
 
 def date_to_season(
-    date: pl.Expr, season_start_month: int = 9, season_start_day: int = 1
+    date: pl.Expr, season_start_month: int, season_start_day: int = 1
 ) -> pl.Expr:
     """
     Extract the overwinter disease season from a date

--- a/scripts/config_template.yaml
+++ b/scripts/config_template.yaml
@@ -44,8 +44,6 @@ forecast_dates:
   end: 2021-11-01
   interval: 1mo
 
-score_funs: [mspe, eos_abs_diff]
-
 plots:
   example_data_season: "2020/2021"
   example_forecast_geos: ["New Jersey"]


### PR DESCRIPTION
Simplify the scripts to assume that we are looking at MSPE scores only from the final forecast date (i.e., including all the data, to assess fit), and then end-of-season forecast accuracy scores only for the final (i.e., forecasted) season

Resolves #241 - I had introduced some confusing distinction between "fit" and "forecast" that didn't work out