### PR TITLE
How coefficients affect the shape of spline function

### DIFF
--- a/scripts/gam/spline_viz.py
+++ b/scripts/gam/spline_viz.py
@@ -1,8 +1,8 @@
 # app.py
+import matplotlib.pyplot as plt
 import numpy as np
 import streamlit as st
-import matplotlib.pyplot as plt
-from scipy.interpolate import make_lsq_spline, BSpline
+from scipy.interpolate import BSpline, make_lsq_spline
 
 st.set_page_config(page_title="Interactive LSQ B-splines", layout="wide")
 


### PR DESCRIPTION
I made a streamlit app with the help of ChatGPT...This allows us to change the coefficients and observe how spline changes. To run the app, go to folder `scripts/gam` and `streamlit run spline_viz.py`.

The spline was made by `make_lsq_spline`, with user-defined degree of spline, number of interior knots. The default is a cubic spline (k = 3) with 8 internal knots (m = 8). The number of coefficients (n) follows: 
```math
n = total\ knots - k - 1
```
Meanwhile, 
```math
\begin{align*}
total\ knots &= (k+1) + m + (k+1) \\ 
with& (k+1)\ boundary\ knots\ at\ two\ ends
\end{align*}
```
The default test data is a sine function. We can see all the basis functions by selecting "Show all basis functions" under Highlighting. By changing the coefficients in Preset under Coefficient input, we can see how the resulting spline function changes. 

The conclusion is that, yes, the coefficients substantially affect the shape of the spline function, with no shared similarities. But putting a scaling factor ensures the same shape of spline function (see Scaled baseline (0.4x)). 

This validate our next step, fitting global coefficients and group-level specific scaling factor. While this only reflects the shape of the most of datasets by season/state, we can give it a try first, then there are other options (group-specific coefficients, same wiggliness ($\lambda$)). 