### PR TITLE
Use arrays

### DIFF
--- a/iup/__init__.py
+++ b/iup/__init__.py
@@ -155,6 +155,4 @@ class SampleForecast(Data):
     """
 
     def validate(self):
-        self.assert_in_schema(
-            {"time_end": pl.Date, "sample_id": pl.UInt64, "estimate": pl.Float64}
-        )
+        self.assert_in_schema({"time_end": pl.Date, "samples": pl.Array})

--- a/iup/models.py
+++ b/iup/models.py
@@ -248,28 +248,22 @@ class LPLModel(CoverageModel):
 
         # observations are rows; posterior samples are columns
         pred = np.array(pred["obs"]).transpose()
+        assert pred.shape == (
+            self.data.height,
+            self.mcmc_params["num_samples"] * self.mcmc_params["num_chains"],
+        )
 
         # put predictions into a dataframe
-        sample_cols = [f"_sample_{i}" for i in range(pred.shape[1])]
-        pred = pl.DataFrame(pred, schema=sample_cols)
-
-        index_cols = [self.date_column, "elapsed", "N_tot"] + self.groups
+        pred = pl.DataFrame(
+            pred, schema=[("samples", pl.Array(pl.Float64, pred.shape[1]))]
+        )
+        assert pred.shape == (self.data.height, 1)
 
         # combine predictions
         return iup.SampleForecast(
             pl.concat([self.data, pred], how="horizontal")
-            .unpivot(
-                on=sample_cols,
-                index=index_cols,
-                variable_name="sample_id",
-                value_name="estimate",
-            )
             .with_columns(
                 forecast_date=self.forecast_date,
-                # convert from sample_id strings to integers
-                sample_id=pl.col("sample_id")
-                .replace_strict({name: i for i, name in enumerate(sample_cols)})
-                .cast(pl.UInt64),
                 estimate=pl.col("estimate") / pl.col("N_tot"),
             )
             .drop(["elapsed", "N_tot"])

--- a/scripts/plot_preds.py
+++ b/scripts/plot_preds.py
@@ -128,12 +128,12 @@ if __name__ == "__main__":
     half_alpha = (1.0 - config["plots"]["ci_level"]) / 2
     pred_cones = (
         preds.filter(pl.col("time_end") > pl.col("forecast_date"))
-        .group_by(["season", "geography", "time_end", "model", "forecast_date"])
-        .agg(
-            pl.col("estimate").median().alias("pred_estimate"),
-            pl.col("estimate").quantile(half_alpha).alias("pred_lci"),
-            pl.col("estimate").quantile(1.0 - half_alpha).alias("pred_uci"),
+        .with_columns(
+            pred_estimate=pl.col("samples").arr.agg(pl.element().median()),
+            pred_lci=pl.col("samples").arr.agg(pl.element().quantile(half_alpha)),
+            pred_uci=pl.col("samples").arr.agg(pl.element().quantile(1.0 - half_alpha)),
         )
+        .drop("samples")
     )
 
     # get all the target dates & forecast dates

--- a/scripts/plot_preds.py
+++ b/scripts/plot_preds.py
@@ -64,20 +64,11 @@ def plot_fit(
     season: str,
     sort_month: List[str],
 ) -> alt.LayerChart:
-    pred_to_plot = (
-        pred.filter(
-            pl.col("forecast_date") == pl.col("forecast_date").max(),
-            pl.col("geography") == pl.lit(geography),
-            pl.col("season") == pl.lit(season),
-        )
-        .group_by(["season", "geography", "time_end", "model", "forecast_date"])
-        .agg(
-            pl.col("estimate").median().alias("pred_estimate"),
-            pl.col("estimate").quantile(half_alpha).alias("pred_lci"),
-            pl.col("estimate").quantile(1.0 - half_alpha).alias("pred_uci"),
-        )
-        .collect()
-    )
+    pred_to_plot = pred.filter(
+        pl.col("forecast_date") == pl.col("forecast_date").max(),
+        pl.col("geography") == pl.lit(geography),
+        pl.col("season") == pl.lit(season),
+    ).collect()
 
     assert pred_to_plot["forecast_date"].unique().len() == 1
 
@@ -107,15 +98,17 @@ if __name__ == "__main__":
     p.add_argument("--output", required=True, help="output flag file")
     args = p.parse_args()
 
-    with open(args.config) as f:
-        config = yaml.safe_load(f)
-
-    obs_raw = pl.read_parquet(args.data)
-    preds = pl.scan_parquet(args.preds)
-
     out_flag = Path(args.output)
     out_dir = out_flag.parent
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(args.config) as f:
+        config = yaml.safe_load(f)
+
+    half_alpha = (1.0 - config["plots"]["ci_level"]) / 2
+
+    obs_raw = pl.read_parquet(args.data)
+    pred_raw = pl.scan_parquet(args.preds)
 
     # clean data
     obs = (
@@ -124,20 +117,14 @@ if __name__ == "__main__":
         .with_columns(month=pl.col("time_end").dt.to_string("%b"))
     )
 
-    # get the prediction cones
-    half_alpha = (1.0 - config["plots"]["ci_level"]) / 2
-    pred_cones = (
-        preds.filter(pl.col("time_end") > pl.col("forecast_date"))
-        .with_columns(
-            pred_estimate=pl.col("samples").arr.agg(pl.element().median()),
-            pred_lci=pl.col("samples").arr.agg(pl.element().quantile(half_alpha)),
-            pred_uci=pl.col("samples").arr.agg(pl.element().quantile(1.0 - half_alpha)),
-        )
-        .drop("samples")
-    )
+    pred = pred_raw.with_columns(
+        pred_estimate=pl.col("samples").arr.agg(pl.element().median()),
+        pred_lci=pl.col("samples").arr.agg(pl.element().quantile(half_alpha)),
+        pred_uci=pl.col("samples").arr.agg(pl.element().quantile(1.0 - half_alpha)),
+    ).drop("samples")
 
     # get all the target dates & forecast dates
-    fc = pred_cones.collect()
+    fc = pred.filter(pl.col("time_end") > pl.col("forecast_date")).collect()
 
     fc_plot_data = (
         obs.join(fc.select(pl.col("forecast_date").unique()), how="cross")
@@ -157,7 +144,7 @@ if __name__ == "__main__":
     for geo in config["plots"]["example_geos"]:
         plot_fit(
             data=obs,
-            pred=preds,
+            pred=pred,
             geography=geo,
             season=config["plots"]["example_season"],
             sort_month=sort_month,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -127,6 +127,7 @@ def test_quantile_forecast_validation():
 def test_sample_forecast_validation():
     iup.SampleForecast(
         pl.DataFrame(
-            {"time_end": [dt.date(2020, 1, 1)], "estimate": [0.0], "sample_id": 0}
-        ).with_columns(pl.col("sample_id").cast(pl.UInt64))
+            {"time_end": [dt.date(2020, 1, 1)], "samples": [[0.0, 0.1, 0.2, 0.3]]},
+            schema=[("time_end", dt.date), ("samples", pl.Array(pl.Float64, 4))],
+        )
     )


### PR DESCRIPTION
I was thinking about why the data weren't that big on disk but took up lots of space in memory. My guess is that it's because we had data in long format, with many repeated values. On disk, that would be compressed.

So an alternative would be a wide format, but one where we don't put the individual samples in their own column, but instead have a single array column.