### PR TITLE
Dagster: Put assets.py at top level

### DIFF
--- a/assets.py
+++ b/assets.py
@@ -7,7 +7,7 @@ import yaml
 
 import scripts.preprocess
 
-repo_dir = Path(__file__).parent.parent.parent
+repo_dir = Path(__file__).parent
 raw_data_path = repo_dir / "data" / "raw.parquet"
 config_path = repo_dir / "scripts" / "config_vignette.yaml"
 output = "output/vignette/data.parquet"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tasks.dg]
-run = "DAGSTER_HOME=$(pwd -P)/.dagster_home dg launch --assets 'data'"
+run = "DAGSTER_HOME=$(pwd -P)/.dagster_home dg launch --assets '*' -f assets.py"

--- a/vcf/definitions.py
+++ b/vcf/definitions.py
@@ -1,8 +1,0 @@
-from pathlib import Path
-
-from dagster import definitions, load_from_defs_folder
-
-
-@definitions
-def defs():
-    return load_from_defs_folder(path_within_project=Path(__file__).parent)


### PR DESCRIPTION
Builds off #330 , showing an option for how you can put `assets.py` at the top level