### PR TITLE
Suggestion: date checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,6 @@ FORECAST_DATES = $(shell python scripts/get_forecast_dates.py --config=$(CONFIG)
 PREDS = $(foreach date,$(FORECAST_DATES),$(PRED_DIR)/forecast_date=$(date)/part-0.parquet)
 FITS = $(foreach date,$(FORECAST_DATES),$(OUTPUT_DIR)/fits/fit_$(date).pkl)
 
-ifeq ($(FORECAST_DATES),forecast date out of data range. )
-$(error forecast date out of data range, check config)
-endif
-
 # This variable because the pattern `forecast_date=2020-01-01` confuses make.
 # It thinks `=%` is variable assignment, not pattern matching.
 # So we need `forecast_date$(EQ)%`.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CONFIG = scripts/config_vignette.yaml
+CONFIG = scripts/config_full.yaml
 RAW_DATA = data/raw.parquet
 
 RUN_ID = $(shell python scripts/get_run_id.py --config=$(CONFIG))
@@ -18,6 +18,10 @@ PLOT_SCORES = $(OUTPUT_DIR)/plots/.scores.checkpoint
 FORECAST_DATES = $(shell python scripts/get_forecast_dates.py --config=$(CONFIG))
 PREDS = $(foreach date,$(FORECAST_DATES),$(PRED_DIR)/forecast_date=$(date)/part-0.parquet)
 FITS = $(foreach date,$(FORECAST_DATES),$(OUTPUT_DIR)/fits/fit_$(date).pkl)
+
+ifeq ($(FORECAST_DATES),forecast date out of data range. )
+$(error forecast date out of data range, check config)
+endif
 
 # This variable because the pattern `forecast_date=2020-01-01` confuses make.
 # It thinks `=%` is variable assignment, not pattern matching.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CONFIG = scripts/config_full.yaml
+CONFIG = scripts/config_vignette.yaml
 RAW_DATA = data/raw.parquet
 
 RUN_ID = $(shell python scripts/get_run_id.py --config=$(CONFIG))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "numpyro>=0.16.1,<0.17",
     "jax>=0.5.0,<0.6",
     "scipy>=1.15.3",
+    "pre-commit>=4.6.0",
 ]
 
 [build-system]

--- a/scripts/config_full.yaml
+++ b/scripts/config_full.yaml
@@ -32,6 +32,9 @@ models:
       num_samples: 500
       num_chains: 4
       progress_bar: false
+  - name: RFModel
+    params:
+      n_estimators: 100
 
 forecast_dates:
   start: 2021-07-01

--- a/scripts/get_forecast_dates.py
+++ b/scripts/get_forecast_dates.py
@@ -1,4 +1,5 @@
 import argparse
+from datetime import date
 
 import polars as pl
 import yaml
@@ -18,4 +19,17 @@ if __name__ == "__main__":
         eager=True,
     )
 
-    print(*forecast_dates, sep=" ")
+    if forecast_dates[0] < date(
+        config["season"]["start_year"],
+        config["season"]["start_month"],
+        config["season"]["start_day"],
+    ):
+        print("forecast date out of data range. ")
+    elif forecast_dates[-1] > date(
+        config["season"]["end_year"],
+        config["season"]["end_month"],
+        config["season"]["end_day"],
+    ):
+        print("forecast date out of data range. ")
+    else:
+        print(*forecast_dates, sep=" ")

--- a/scripts/get_forecast_dates.py
+++ b/scripts/get_forecast_dates.py
@@ -12,6 +12,21 @@ if __name__ == "__main__":
     with open(args.config) as f:
         config = yaml.safe_load(f)
 
+    first_date = date(
+        config["season"]["start_year"],
+        config["season"]["start_month"],
+        config["season"]["start_day"],
+    )
+
+    last_date = date(
+        config["season"]["end_year"],
+        config["season"]["end_month"],
+        config["season"]["end_day"],
+    )
+
+    assert config["forecast_dates"]["start"] >= first_date
+    assert config["forecast_dates"]["end"] <= last_date
+
     forecast_dates = pl.date_range(
         config["forecast_dates"]["start"],
         config["forecast_dates"]["end"],
@@ -19,17 +34,4 @@ if __name__ == "__main__":
         eager=True,
     )
 
-    if forecast_dates[0] < date(
-        config["season"]["start_year"],
-        config["season"]["start_month"],
-        config["season"]["start_day"],
-    ):
-        print("forecast date out of data range. ")
-    elif forecast_dates[-1] > date(
-        config["season"]["end_year"],
-        config["season"]["end_month"],
-        config["season"]["end_day"],
-    ):
-        print("forecast date out of data range. ")
-    else:
-        print(*forecast_dates, sep=" ")
+    print(*forecast_dates, sep=" ")

--- a/scripts/get_forecast_dates.py
+++ b/scripts/get_forecast_dates.py
@@ -29,12 +29,7 @@ if __name__ == "__main__":
     forecast_start = config["forecast_dates"]["start"]
     forecast_end = config["forecast_dates"]["end"]
 
-    # are universe and forecast bounds ordered?
-    assert data_start < data_end
-    assert forecast_start <= forecast_end
-    # are forecast dates inside the data dates?
-    assert data_start <= forecast_start
-    assert forecast_end <= data_end
+    assert data_start <= forecast_start <= forecast_end <= data_end
 
     forecast_dates = pl.date_range(
         forecast_start,

--- a/scripts/get_forecast_dates.py
+++ b/scripts/get_forecast_dates.py
@@ -12,24 +12,33 @@ if __name__ == "__main__":
     with open(args.config) as f:
         config = yaml.safe_load(f)
 
-    first_date = date(
+    # start and end dates of all included data
+    data_start = date(
         config["season"]["start_year"],
         config["season"]["start_month"],
         config["season"]["start_day"],
     )
 
-    last_date = date(
+    data_end = date(
         config["season"]["end_year"],
         config["season"]["end_month"],
         config["season"]["end_day"],
     )
 
-    assert config["forecast_dates"]["start"] >= first_date
-    assert config["forecast_dates"]["end"] <= last_date
+    # first and last forecast dates
+    forecast_start = config["forecast_dates"]["start"]
+    forecast_end = config["forecast_dates"]["end"]
+
+    # are universe and forecast bounds ordered?
+    assert data_start < data_end
+    assert forecast_start <= forecast_end
+    # are forecast dates inside the data dates?
+    assert data_start <= forecast_start
+    assert forecast_end <= data_end
 
     forecast_dates = pl.date_range(
-        config["forecast_dates"]["start"],
-        config["forecast_dates"]["end"],
+        forecast_start,
+        forecast_end,
         config["forecast_dates"]["interval"],
         eager=True,
     )


### PR DESCRIPTION
If we're doing date checks, I would be a little more robust: we want to make sure these four dates are in order: start of available data, first forecast date, last forecast date, end of data

The thing about returning a string, that make then catches, is very finicky. I'd rather either (1) keep that kind of error handling manual or (2) migrate to Snakemake or some other framework.

Also, again, I think it's important that we use the vignette config by default. If you want to run another config, you should `make CONFIG=scripts/config_full.yaml`.

Finally, I this doesn't throw any error for me? Like, maybe it's nice to have this check, but I'm not getting an error?